### PR TITLE
Fix Kafka topic mismatch in training services

### DIFF
--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/CapacitacionService.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/CapacitacionService.java
@@ -27,8 +27,8 @@ public class CapacitacionService {
     public CapacitacionDto create(CapacitacionDto dto) {
         Capacitacion e = mapper.toEntity(dto);
         Capacitacion saved = repo.save(e);
-        // publicar evento de dominio
-        kafka.send("training.scheduled", saved.getId());
+        // publicar evento de dominio en el tópico escuchado por servicio-consultas
+        kafka.send("servicioEntrenamiento.scheduled", saved.getId());
         return mapper.toDto(saved);
     }
 

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/EvaluacionService.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/EvaluacionService.java
@@ -27,7 +27,8 @@ public class EvaluacionService {
     public EvaluacionDto create(EvaluacionDto dto) {
         EvaluacionDesempeno e = mapper.toEntity(dto);
         EvaluacionDesempeno saved = repo.save(e);
-        kafka.send("training.evaluated", saved.getId());
+        // publicar evento de evaluación en el tópico consumido por servicio-consultas
+        kafka.send("servicioEntrenamiento.evaluated", saved.getId());
         return mapper.toDto(saved);
     }
 


### PR DESCRIPTION
## Summary
- publish Capacitacion events on `servicioEntrenamiento.scheduled`
- publish Evaluacion events on `servicioEntrenamiento.evaluated`

## Testing
- `./mvnw -q -pl servicio-entrenamiento -am test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6847f4ab74e48324ac6c44020a6a9e6a