### PR TITLE
Update training events payload

### DIFF
--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/CapacitacionService.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/CapacitacionService.java
@@ -28,7 +28,7 @@ public class CapacitacionService {
         Capacitacion e = mapper.toEntity(dto);
         Capacitacion saved = repo.save(e);
         // publicar evento de dominio
-        kafka.send("training.scheduled", saved.getId());
+        kafka.send("servicioEntrenamiento.scheduled", mapper.toDto(saved));
         return mapper.toDto(saved);
     }
 

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/EvaluacionService.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/EvaluacionService.java
@@ -27,7 +27,7 @@ public class EvaluacionService {
     public EvaluacionDto create(EvaluacionDto dto) {
         EvaluacionDesempeno e = mapper.toEntity(dto);
         EvaluacionDesempeno saved = repo.save(e);
-        kafka.send("training.evaluated", saved.getId());
+        kafka.send("servicioEntrenamiento.evaluated", mapper.toDto(saved));
         return mapper.toDto(saved);
     }
 


### PR DESCRIPTION
## Summary
- publish whole `CapacitacionDto` when a training is scheduled
- publish whole `EvaluacionDto` when a training evaluation is created

## Testing
- `./mvnw -q -pl servicio-entrenamiento -am test` *(fails: cannot fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6847fcccd19083249f934717f023195f