### PR TITLE
Remove duplicate kafka topics

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/config/KafkaConfiguration.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/config/KafkaConfiguration.java
@@ -87,15 +87,7 @@ public class KafkaConfiguration {
         return TopicBuilder.name("servicioEntrenamiento.turno.created").partitions(1).replicas(1).build();
     }
 
-    @Bean
-    public NewTopic capacitacionScheduledTopic() {
-        return TopicBuilder.name("servicioEntrenamiento.scheduled").partitions(1).replicas(1).build();
-    }
 
-    @Bean
-    public NewTopic evaluacionTopic() {
-        return TopicBuilder.name("servicioEntrenamiento.evaluated").partitions(1).replicas(1).build();
-    }
 
     @Bean
     public NewTopic nominaGeneratedTopic() {


### PR DESCRIPTION
## Summary
- clean up Kafka config
  - remove redundant beans that build the same topics

## Testing
- `mvnw -q test` *(fails: Failed to fetch apache-maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6847fcd198cc8324aa22b6f96ad38d8a