### PR TITLE
Add warning log for SagaState save errors

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/servicio/SagaStateService.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/servicio/SagaStateService.java
@@ -7,6 +7,8 @@ import ar.org.hospitalcuencaalta.servicio_orquestador.repositorio.SagaStateRepos
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +18,8 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class SagaStateService {
+
+    private static final Logger log = LoggerFactory.getLogger(SagaStateService.class);
 
     private final SagaStateRepository repository;
     private final ObjectMapper objectMapper;
@@ -30,6 +34,7 @@ public class SagaStateService {
             String json = objectMapper.writeValueAsString(stateMachine.getExtendedState().getVariables());
             state.setExtendedState(json);
         } catch (JsonProcessingException e) {
+            log.warn("[SagaStateService] No se pudo convertir el estado extendido a JSON para saga '{}': {}", sagaId, e.toString());
             state.setExtendedState(null);
         }
         state.setUpdatedAt(Instant.now());


### PR DESCRIPTION
## Summary
- log `JsonProcessingException` in `SagaStateService.save`

## Testing
- `./mvnw -q test -pl servicio-orquestador` *(fails: unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849e7ec1754832488abc3fd0472a9c1