### PR TITLE
Add integration test for saga status endpoint

### DIFF
--- a/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerIntegrationTest.java
+++ b/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerIntegrationTest.java
@@ -5,6 +5,9 @@ import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Eventos;
 import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.ContratoLaboralDto;
 import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.EmpleadoDto;
 import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.SagaEmpleadoContratoRequest;
+import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.SagaStatusResponse;
+import ar.org.hospitalcuencaalta.servicio_orquestador.servicio.SagaStateService;
+import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.SagaState;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,13 +27,17 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import reactor.core.publisher.Flux;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 /**
  * Test de integración para SagaController:
@@ -59,6 +66,12 @@ class SagaControllerIntegrationTest {
      */
     @MockitoBean
     private StateMachine<Estados, Eventos> stateMachine;
+
+    /**
+     * Mockeamos SagaStateService para simular lecturas del estado de la SAGA.
+     */
+    @MockitoBean
+    private SagaStateService sagaStateService;
 
     @BeforeEach
     void setup() {
@@ -111,5 +124,36 @@ class SagaControllerIntegrationTest {
 
         // 4) Verificar que sendEvents(...) se llamó exactamente 1 vez
         verify(stateMachine, times(1)).sendEvents(any(Flux.class));
+    }
+
+    @Test
+    void obtenerSaga_integration_shouldReturnExpectedJson() throws Exception {
+        // 1) Configurar SagaState simulado
+        Instant updated = Instant.parse("2025-08-01T00:00:00Z");
+        SagaState sagaState = SagaState.builder()
+                .sagaId("abc-123")
+                .estado(Estados.FINALIZADA)
+                .updatedAt(updated)
+                .build();
+        when(sagaStateService.findById("abc-123")).thenReturn(Optional.of(sagaState));
+
+        // 2) JSON esperado
+        SagaStatusResponse expected = SagaStatusResponse.builder()
+                .sagaId("abc-123")
+                .estadoActual("FINALIZADA")
+                .idEmpleadoCreado(null)
+                .idContratoCreado(null)
+                .mensajeError(null)
+                .timestampInicio(null)
+                .timestampFin(updated)
+                .build();
+        String expectedJson = objectMapper.writeValueAsString(expected);
+
+        // 3) Realizar GET y verificar JSON
+        mockMvc.perform(get("/api/saga/empleado-contrato/{id}", "abc-123"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
+
+        verify(sagaStateService, times(1)).findById("abc-123");
     }
 }


### PR DESCRIPTION
## Summary
- verify GET `/api/saga/empleado-contrato/{id}`
- mock `SagaStateService` to return saga state and check JSON response

## Testing
- `./mvnw -q -pl servicio-orquestador test` *(fails: wget unable to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6849e7edbe288324a3d7f89cdcf3a3dc