### PR TITLE
Add README with build and test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# RRHH Microservices
+
+This repository contains several Spring Boot services that compose the human resources system.
+
+## Prerequisites
+
+- **JDK 17** must be installed and available in your `PATH`.
+- **MariaDB** should be running locally for development/production profiles.
+- **Docker** and **Docker Compose** for optional infrastructure (Kafka and Zookeeper). A `compose.yaml` file is provided.
+
+Tests use the in-memory **H2** database so no additional setup is required for them.
+
+## Building and Running Services
+
+Each service module contains its own Maven wrapper script. Navigate to the desired module and execute:
+
+```bash
+./mvnw spring-boot:run
+```
+
+Available modules include:
+
+- `comunes`
+- `servicio-contrato`
+- `servicio-empleado`
+- `servicio-entrenamiento`
+- `servicio-nomina`
+- `servicio-orquestador`
+- `servicio-consultas`
+- `API-gateway`
+- `servidor-para-descubrimiento`
+
+From the repository root you can build all modules at once:
+
+```bash
+./mvnw clean package
+```
+
+## Running Tests
+
+Execute tests for all modules with:
+
+```bash
+./mvnw test
+```
+
+or inside a specific module:
+
+```bash
+cd servicio-contrato
+./mvnw test
+```
+
+## Docker Compose
+
+A minimal Docker Compose configuration is included to start Kafka and Zookeeper required by the services:
+
+```bash
+docker compose up -d
+```
+
+Ensure your local MariaDB instance is running before starting the services. Tests will automatically use H2.
+


### PR DESCRIPTION
## Summary
- add root README describing prerequisites, how to run the Maven wrapper, and Docker compose

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6849e7f0b06c83249d0c3f0dae8d8a01