### PR TITLE
Add automatic saga finalization on contrato creation

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -93,13 +93,24 @@ public class SagaStateMachineConfig
                     sagaStateService.save(context.getStateMachine());
                 })
 
-                // ⑧ Al entrar en COMPENSAR_EMPLEADO
+                // ⑧ Al entrar en CONTRATO_CREADO enviamos FINALIZAR
+                .stateEntry(Estados.CONTRATO_CREADO, context -> {
+                    StateMachine<Estados, Eventos> sm = context.getStateMachine();
+                    Message<Eventos> msg = MessageBuilder
+                            .withPayload(Eventos.FINALIZAR)
+                            .build();
+                    sm.sendEvent(Mono.just(msg)).subscribe();
+                    sagaStateService.save(sm);
+                    log.info("[SAGA] {} enviado", Eventos.FINALIZAR);
+                })
+
+                // ⑨ Al entrar en COMPENSAR_EMPLEADO
                 .stateEntry(Estados.COMPENSAR_EMPLEADO, context -> {
                     compensacionActions.compensarEmpleado(context);
                     sagaStateService.save(context.getStateMachine());
                 })
 
-                // ⑨ Al entrar en FINALIZADA
+                // ⑩ Al entrar en FINALIZADA
                 .stateEntry(Estados.FINALIZADA, context -> {
                     completionActions.onSagaCompleted(context);
                     sagaStateService.save(context.getStateMachine());

--- a/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/SagaStateMachineConfigTest.java
+++ b/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/SagaStateMachineConfigTest.java
@@ -1,0 +1,53 @@
+package ar.org.hospitalcuencaalta.servicio_orquestador;
+
+import ar.org.hospitalcuencaalta.servicio_orquestador.accion.CompensacionSagaActions;
+import ar.org.hospitalcuencaalta.servicio_orquestador.accion.ContratoSagaActions;
+import ar.org.hospitalcuencaalta.servicio_orquestador.accion.EmpleadoSagaActions;
+import ar.org.hospitalcuencaalta.servicio_orquestador.accion.SagaCompletionActions;
+import ar.org.hospitalcuencaalta.servicio_orquestador.config.SagaStateMachineConfig;
+import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Estados;
+import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Eventos;
+import ar.org.hospitalcuencaalta.servicio_orquestador.servicio.SagaStateService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(classes = SagaStateMachineConfig.class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class SagaStateMachineConfigTest {
+
+    @Autowired
+    private StateMachineFactory<Estados, Eventos> stateMachineFactory;
+
+    @MockitoBean private EmpleadoSagaActions empleadoActions;
+    @MockitoBean private ContratoSagaActions contratoActions;
+    @MockitoBean private CompensacionSagaActions compensacionActions;
+    @MockitoBean private SagaCompletionActions completionActions;
+    @MockitoBean private SagaStateService sagaStateService;
+
+    @Test
+    void contratoCreadoTriggersFinalizada() {
+        StateMachine<Estados, Eventos> sm = stateMachineFactory.getStateMachine();
+        sm.startReactively().block();
+
+        Message<Eventos> startMsg = MessageBuilder.withPayload(Eventos.SOLICITAR_CREAR_EMPLEADO).build();
+        sm.sendEvent(Mono.just(startMsg)).block();
+        sm.sendEvent(Mono.just(MessageBuilder.withPayload(Eventos.EMPLEADO_CREADO).build())).block();
+        sm.sendEvent(Mono.just(MessageBuilder.withPayload(Eventos.CONTRATO_CREADO).build())).block();
+
+        assertEquals(Estados.FINALIZADA, sm.getState().getId());
+        verify(sagaStateService, atLeastOnce()).save(sm);
+    }
+}


### PR DESCRIPTION
## Summary
- finalize saga once `CONTRATO_CREADO` state is reached
- record saga state whenever the final event is triggered
- test that the CONTRATO_CREADO -> FINALIZADA transition is automatic and persists state

## Testing
- `mvn -q -pl servicio-orquestador test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68502ef8beec832490c10cff061c9eb1