### PR TITLE
Ensure saga state uses numeric identity

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/SagaState.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/SagaState.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
@@ -23,8 +25,10 @@ import java.time.Instant;
 public class SagaState {
 
     @Id
-    @Column(name = "saga_id")
-    private String sagaId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "saga_id", columnDefinition = "BIGINT", updatable = false, nullable = false)
+    private Long sagaId;
+
 
     @Enumerated(EnumType.STRING)
     @Column(name = "estado", nullable = false)
@@ -36,4 +40,5 @@ public class SagaState {
 
     @Column(name = "updated_at")
     private Instant updatedAt;
+
 }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/repositorio/SagaStateRepository.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/repositorio/SagaStateRepository.java
@@ -3,5 +3,5 @@ package ar.org.hospitalcuencaalta.servicio_orquestador.repositorio;
 import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.SagaState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SagaStateRepository extends JpaRepository<SagaState, String> {
+public interface SagaStateRepository extends JpaRepository<SagaState, Long> {
 }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/web/dto/SagaStatusResponse.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/web/dto/SagaStatusResponse.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 @Builder
 public class SagaStatusResponse {
     /**
-     * ID único de la máquina de estados (UUID)
+     * Identificador generado de la saga.
      */
     private String sagaId;
 

--- a/servicio-orquestador/src/main/resources/db/changelog/001-create-saga-states-table.xml
+++ b/servicio-orquestador/src/main/resources/db/changelog/001-create-saga-states-table.xml
@@ -5,7 +5,7 @@
                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
     <changeSet id="001-create-saga-states-table" author="msamia">
         <createTable tableName="saga_states">
-            <column name="saga_id" type="VARCHAR(36)">
+            <column name="saga_id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="estado" type="VARCHAR(50)"/>

--- a/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerWebSliceTest.java
+++ b/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerWebSliceTest.java
@@ -27,7 +27,6 @@ import reactor.core.publisher.Flux;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -72,9 +71,8 @@ class SagaControllerWebSliceTest {
 
     @BeforeEach
     void setup() {
-        // 1) Cuando el controlador llame a stateMachineFactory.getStateMachine(UUID), devolvemos el mock 'stateMachine':
-        when(stateMachineFactory.getStateMachine(any(String.class)))
-                .thenReturn(stateMachine);
+        // 1) Cuando el controlador solicite una nueva state machine, devolvemos el mock:
+        when(stateMachineFactory.getStateMachine()).thenReturn(stateMachine);
 
         // 2) Para evitar NPE en getExtendedState().getVariables().put(...):
         doReturn(new DefaultExtendedState()).when(stateMachine).getExtendedState();
@@ -84,8 +82,6 @@ class SagaControllerWebSliceTest {
                 .when(stateMachine)
                 .sendEvents(any(Flux.class));
 
-        // 4) Stubear getUuid() del stateMachine → siempre un UUID no nulo:
-        doReturn(UUID.randomUUID()).when(stateMachine).getUuid();
 
         // 5) Stubear getState() → un State<Estados, Eventos> cuyo getId() sea INICIO
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- replace UUID saga IDs with auto-increment identity columns
- store saga database ID in state machine extended state
- adjust controller and tests to handle numeric IDs

## Testing
- `./mvnw -q -pl servicio-orquestador test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850d6015a008324bed990a81176b1fb