### PR TITLE
Add Postman tests for Saga update and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,9 @@ Ensure your local MariaDB instance is running before starting the services. Test
 
 
 
+
+## Postman Tests
+
+Sample Postman collection files are provided under `docs/postman`. Import
+`rrhh-saga-tests.postman_collection.json` into Postman to try the SAGA
+update and delete flows via the `/api/saga/empleado-contrato` endpoints.

--- a/docs/postman/rrhh-saga-tests.postman_collection.json
+++ b/docs/postman/rrhh-saga-tests.postman_collection.json
@@ -1,0 +1,100 @@
+{
+  "info": {
+    "name": "RRHH Saga Tests",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Actualizar empleado y contrato",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8095",
+          "path": [
+            "api",
+            "saga",
+            "empleado-contrato",
+            "{{empleadoId}}"
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"empleado\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Perez\",\n    \"documento\": \"12345678\",\n    \"fechaNacimiento\": \"1990-01-01\"\n  },\n  \"contrato\": {\n    \"id\": {{contratoId}},\n    \"empleadoId\": {{empleadoId}},\n    \"fechaInicio\": \"2023-01-01\",\n    \"fechaFin\": \"2023-12-31\",\n    \"tipo\": \"PLANTA\",\n    \"regimen\": \"TIEMPO_COMPLETO\",\n    \"salario\": 35000\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const data = pm.response.json();",
+              "pm.test('Saga creada', function () {",
+              "    pm.expect(data.sagaId).to.be.a('string');",
+              "});",
+              "pm.test('Estado inicial correcto', function () {",
+              "    pm.expect(data.estadoActual).to.be.oneOf(['INICIO', 'ACTUALIZAR_EMPLEADO']);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Eliminar empleado y contrato",
+      "request": {
+        "method": "DELETE",
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8095",
+          "path": [
+            "api",
+            "saga",
+            "empleado-contrato",
+            "{{empleadoId}}"
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const data = pm.response.json();",
+              "pm.test('Saga creada', function () {",
+              "    pm.expect(data.sagaId).to.be.a('string');",
+              "});",
+              "pm.test('Estado inicial correcto', function () {",
+              "    pm.expect(data.estadoActual).to.be.oneOf(['INICIO', 'ELIMINAR_CONTRATO']);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Postman collection containing PUT and DELETE saga examples
- document Postman collection in README

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68512e7e525c83248768d41565a74ad6