### PR TITLE
Add POST and GET to Postman Saga collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ Ensure your local MariaDB instance is running before starting the services. Test
 
 Sample Postman collection files are provided under `docs/postman`. Import
 `rrhh-saga-tests.postman_collection.json` into Postman to try the SAGA
-update and delete flows via the `/api/saga/empleado-contrato` endpoints.
+create, update, delete and status flows via the `/api/saga/empleado-contrato`
+endpoints.
 
 For deletions, pass both the employee id and the `contratoId` as a query
 parameter, e.g. `DELETE /api/saga/empleado-contrato/5?contratoId=10`.
+Use `GET /api/saga/empleado-contrato/{sagaId}` to inspect a saga's state.
 

--- a/docs/postman/rrhh-saga-tests.postman_collection.json
+++ b/docs/postman/rrhh-saga-tests.postman_collection.json
@@ -5,6 +5,56 @@
   },
   "item": [
     {
+      "name": "Crear empleado y contrato",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8095",
+          "path": [
+            "api",
+            "saga",
+            "empleado-contrato"
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"empleado\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Perez\",\n    \"documento\": \"12345678\",\n    \"fechaNacimiento\": \"1990-01-01\"\n  },\n  \"contrato\": {\n    \"fechaInicio\": \"2023-01-01\",\n    \"fechaFin\": \"2023-12-31\",\n    \"tipo\": \"PLANTA\",\n    \"regimen\": \"TIEMPO_COMPLETO\",\n    \"salario\": 35000\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const data = pm.response.json();",
+              "pm.test('Saga creada', function () {",
+              "    pm.expect(data.sagaId).to.be.a('string');",
+              "});",
+              "pm.test('Estado inicial correcto', function () {",
+              "    pm.expect(data.estadoActual).to.be.oneOf(['INICIO', 'CREAR_EMPLEADO']);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
       "name": "Actualizar empleado y contrato",
       "request": {
         "method": "PUT",
@@ -97,6 +147,39 @@
               "});",
               "pm.test('Estado inicial correcto', function () {",
               "    pm.expect(data.estadoActual).to.be.oneOf(['INICIO', 'ELIMINAR_CONTRATO']);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Consultar estado de la SAGA",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{sagaId}}",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8095",
+          "path": [
+            "api",
+            "saga",
+            "empleado-contrato",
+            "{{sagaId}}"
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
               "});"
             ],
             "type": "text/javascript"


### PR DESCRIPTION
## Summary
- expand Postman collection with create and status requests
- document new endpoints in README

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685146637990832489f9603e1e21e752