### PR TITLE
Add Circuit Breaker test to Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,9 @@ For deletions, pass both the employee id and the `contratoId` as a query
 parameter, e.g. `DELETE /api/saga/empleado-contrato/5?contratoId=10`.
 Use `GET /api/saga/empleado-contrato/{sagaId}` to inspect a saga's state.
 
+To check if the circuit breaker for employee creation opens, make several failing
+requests (for instance by stopping `servicio-empleado`) and then send a `GET`
+request to `http://localhost:8095/actuator/circuitbreakers/crearEmpleadoCB?includeState=true`.
+The `Estado Circuit Breaker crearEmpleadoCB` request in the Postman collection
+expects the breaker state to be `OPEN`.
+

--- a/docs/postman/rrhh-saga-tests.postman_collection.json
+++ b/docs/postman/rrhh-saga-tests.postman_collection.json
@@ -186,6 +186,45 @@
           }
         }
       ]
+    },
+    {
+      "name": "Estado Circuit Breaker crearEmpleadoCB",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/actuator/circuitbreakers/crearEmpleadoCB?includeState=true",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8095",
+          "path": [
+            "actuator",
+            "circuitbreakers",
+            "crearEmpleadoCB"
+          ],
+          "query": [
+            {
+              "key": "includeState",
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('CircuitBreaker abierto', function () {",
+              "    const data = pm.response.json();",
+              "    pm.expect(data.state).to.eql('OPEN');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add request to verify `crearEmpleadoCB` circuit breaker state in Postman collection
- document how to open the circuit breaker before running the request

## Testing
- `jq '.' docs/postman/rrhh-saga-tests.postman_collection.json >/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_685154f676f88324a9bf9a3419cda8dd