### PR TITLE
Fix circuit breaker status URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Use `GET /api/saga/empleado-contrato/{sagaId}` to inspect a saga's state.
 To check if the circuit breaker for employee creation opens, make several failing
 requests (for instance by stopping `servicio-empleado`) and then send a `GET`
 
-request to `http://localhost:8095/actuator/resilience4j/circuitbreakers/crearEmpleadoCB?includeState=true`.
+request to `http://localhost:8095/actuator/circuitbreakers/crearEmpleadoCB?includeState=true`.
 
 The `Estado Circuit Breaker crearEmpleadoCB` request in the Postman collection
 expects the breaker state to be `OPEN`.

--- a/docs/postman/rrhh-saga-tests.postman_collection.json
+++ b/docs/postman/rrhh-saga-tests.postman_collection.json
@@ -195,7 +195,7 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/actuator/resilience4j/circuitbreakers/crearEmpleadoCB?includeState=true",
+          "raw": "http://localhost:8095/actuator/circuitbreakers/crearEmpleadoCB?includeState=true",
           "protocol": "http",
           "host": [
             "localhost"
@@ -203,7 +203,6 @@
           "port": "8095",
           "path": [
             "actuator",
-            "resilience4j",
             "circuitbreakers",
             "crearEmpleadoCB"
           ],


### PR DESCRIPTION
## Summary
- correct the circuit breaker endpoint URL in the docs
- update Postman collection accordingly

## Testing
- `mvn -q test -pl servicio-orquestador -am` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68514e795ef883248eb1b57a9ef9fb4a