### PR TITLE
Integrate consultas updates with saga events

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,6 @@ services:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     - ALLOW_PLAINTEXT_LISTENER=yes
     # Auto-create all required topics
-    - KAFKA_CREATE_TOPICS=empleado.created:1:1,empleado.updated:1:1,empleado.deleted:1:1,servicioContrato.contrato.created:1:1,servicioContrato.contrato.deleted:1:1,servicioContrato.asistencia.created:1:1,servicioContrato.licencia.created:1:1,servicioContrato.vacacion.created:1:1,servicioEntrenamiento.scheduled:1:1,servicioEntrenamiento.updated:1:1,servicioEntrenamiento.evaluated:1:1,servicioEntrenamiento.turno.created:1:1,servicioNomina.nomina.generated:1:1,servicioNomina.added:1:1
+    - KAFKA_CREATE_TOPICS=empleado.created:1:1,empleado.updated:1:1,empleado.deleted:1:1,servicioContrato.contrato.created:1:1,servicioContrato.contrato.updated:1:1,servicioContrato.contrato.deleted:1:1,servicioContrato.asistencia.created:1:1,servicioContrato.licencia.created:1:1,servicioContrato.vacacion.created:1:1,servicioEntrenamiento.scheduled:1:1,servicioEntrenamiento.updated:1:1,servicioEntrenamiento.evaluated:1:1,servicioEntrenamiento.turno.created:1:1,servicioNomina.nomina.generated:1:1,servicioNomina.added:1:1
     depends_on:
       - zookeeper

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/config/KafkaConfiguration.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/config/KafkaConfiguration.java
@@ -48,6 +48,11 @@ public class KafkaConfiguration {
     }
 
     @Bean
+    public NewTopic contratoUpdatedTopic() {
+        return TopicBuilder.name("servicioContrato.contrato.updated").partitions(1).replicas(1).build();
+    }
+
+    @Bean
     public NewTopic contratoDeletedTopic() {
         return TopicBuilder.name("servicioContrato.contrato.deleted").partitions(1).replicas(1).build();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ContratoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ContratoEventListener.java
@@ -19,6 +19,11 @@ public class ContratoEventListener {
         repo.save(mapper.toContrato(dto));
     }
 
+    @KafkaListener(topics = "servicioContrato.contrato.updated")
+    public void onUpdated(ContratoLaboralDto dto) {
+        repo.save(mapper.toContrato(dto));
+    }
+
     @KafkaListener(topics = "servicioContrato.contrato.deleted")
     public void onDeleted(Long id) {
         repo.deleteById(id);

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/ContratoSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/ContratoSagaActions.java
@@ -48,6 +48,8 @@ public class ContratoSagaActions {
                 // Crear contrato
                 ContratoLaboralDto creado = contratoClient.create(contratoDto);
                 Long idContrato = creado.getId();
+                // Guardar DTO completo para eventos finales
+                context.getExtendedState().getVariables().put("contratoDto", creado);
                 log.info("[SAGA] Contrato creado con id={}", idContrato);
 
                 // Guardar idContrato
@@ -108,7 +110,8 @@ public class ContratoSagaActions {
             ContratoLaboralDto dto = context.getExtendedState().get("contratoDto", ContratoLaboralDto.class);
             StateMachine<Estados, Eventos> machine = context.getStateMachine();
 
-            contratoClient.update(idContrato, dto);
+            ContratoLaboralDto actualizado = contratoClient.update(idContrato, dto);
+            context.getExtendedState().getVariables().put("contratoDto", actualizado);
 
             Message<Eventos> msg = MessageBuilder.withPayload(Eventos.CONTRATO_ACTUALIZADO)
                     .setHeader("idContrato", idContrato)

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/EmpleadoSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/EmpleadoSagaActions.java
@@ -50,6 +50,8 @@ public class EmpleadoSagaActions {
             // 2) Crear empleado
             EmpleadoDto creado = empleadoClient.create(empleadoDto);
             Long idGenerado = creado.getId();
+            // almacenar DTO con ID para eventos finales
+            context.getExtendedState().getVariables().put("empleadoDto", creado);
             log.info("[SAGA] Empleado creado con id={}", idGenerado);
 
             // 3) Guardar idEmpleado en extendedState
@@ -87,7 +89,9 @@ public class EmpleadoSagaActions {
             Long id = context.getExtendedState().get("idEmpleado", Long.class);
             StateMachine<Estados, Eventos> machine = context.getStateMachine();
 
-            empleadoClient.update(id, dto);
+            EmpleadoDto actualizado = empleadoClient.update(id, dto);
+            // mantener DTO actualizado
+            context.getExtendedState().getVariables().put("empleadoDto", actualizado);
 
             Message<Eventos> msg = MessageBuilder.withPayload(Eventos.EMPLEADO_ACTUALIZADO)
                     .setHeader("idEmpleado", id)

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/SagaCompletionActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/SagaCompletionActions.java
@@ -23,11 +23,24 @@ public class SagaCompletionActions {
 
         Long idEmpleado = machine.getExtendedState().get("idEmpleado", Long.class);
         Long idContrato = machine.getExtendedState().get("idContrato", Long.class);
+        String operacion = machine.getExtendedState().get("operacion", String.class);
         String sagaId   = machine.getUuid().toString();
 
-        // Publicar sólo al finalizar satisfactoriamente
-        publisher.publishEmployeeCreated(idEmpleado, Map.of("empleadoId", idEmpleado));
-        publisher.publishContratoCreated(idContrato, Map.of("contratoId", idContrato));
+        // DTOs completos si existen
+        Object empDto = machine.getExtendedState().get("empleadoDto", Object.class);
+        Object conDto = machine.getExtendedState().get("contratoDto", Object.class);
+
+        if ("CREAR".equalsIgnoreCase(operacion)) {
+            if (empDto != null) publisher.publishEmployeeCreated(empDto);
+            if (conDto != null) publisher.publishContratoCreated(conDto);
+        } else if ("ACTUALIZAR".equalsIgnoreCase(operacion)) {
+            if (empDto != null) publisher.publishEmployeeUpdated(empDto);
+            if (conDto != null) publisher.publishContratoUpdated(conDto);
+        } else if ("ELIMINAR".equalsIgnoreCase(operacion)) {
+            if (idContrato != null) publisher.publishContratoDeleted(idContrato);
+            if (idEmpleado != null) publisher.publishEmployeeDeleted(idEmpleado);
+        }
+
         publisher.publishSagaCompleted(sagaId);
     }
 }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/DomainEventPublisher.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/DomainEventPublisher.java
@@ -14,12 +14,28 @@ public class DomainEventPublisher {
         this.kafka = kafka;
     }
 
-    public void publishEmployeeCreated(Long empleadoId, Object payload) {
-        kafka.send("empleado.created", empleadoId.toString(), payload);
+    public void publishEmployeeCreated(Object payload) {
+        kafka.send("empleado.created", payload);
     }
 
-    public void publishContratoCreated(Long contratoId, Object payload) {
-        kafka.send("servicioContrato.contrato.created", contratoId.toString(), payload);
+    public void publishEmployeeUpdated(Object payload) {
+        kafka.send("empleado.updated", payload);
+    }
+
+    public void publishEmployeeDeleted(Long id) {
+        kafka.send("empleado.deleted", id);
+    }
+
+    public void publishContratoCreated(Object payload) {
+        kafka.send("servicioContrato.contrato.created", payload);
+    }
+
+    public void publishContratoUpdated(Object payload) {
+        kafka.send("servicioContrato.contrato.updated", payload);
+    }
+
+    public void publishContratoDeleted(Long id) {
+        kafka.send("servicioContrato.contrato.deleted", id);
     }
 
     public void publishSagaCompleted(String sagaId) {

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaController.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaController.java
@@ -52,6 +52,8 @@ public class SagaController {
                 .put("empleadoDto", request.getEmpleado());
         stateMachine.getExtendedState().getVariables()
                 .put("contratoDto", request.getContrato());
+        stateMachine.getExtendedState().getVariables()
+                .put("operacion", "CREAR");
 
         // Iniciar la máquina de estados de forma sincrónica para garantizar
         // que todas las transiciones posteriores se procesen correctamente.
@@ -111,6 +113,7 @@ public class SagaController {
             vars.remove("contratoDto");
             vars.remove("idContrato");
         }
+        vars.put("operacion", "ACTUALIZAR");
 
         stateMachine.start();
         sagaStateService.save(stateMachine);
@@ -139,6 +142,7 @@ public class SagaController {
 
         stateMachine.getExtendedState().getVariables().put("idEmpleado", id);
         stateMachine.getExtendedState().getVariables().put("idContrato", contratoId);
+        stateMachine.getExtendedState().getVariables().put("operacion", "ELIMINAR");
 
         stateMachine.start();
         sagaStateService.save(stateMachine);


### PR DESCRIPTION
## Summary
- publish employee and contract CRUD events from orchestrator
- store returned DTOs in saga actions
- mark current operation in saga controller
- let consultas service consume contract updated events
- expose new Kafka topic for contract updates

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685162c7fbd08324b465120e859acd1f