### PR TITLE
Add consultas saga Postman tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Ensure your local MariaDB instance is running before starting the services. Test
 Sample Postman collection files are provided under `docs/postman`. Import
 `rrhh-saga-tests.postman_collection.json` into Postman to try the SAGA
 create, update, delete and status flows via the `/api/saga/empleado-contrato`
-endpoints.
+endpoints. The file `consultas-saga-tests.postman_collection.json` contains
+additional requests that validate how `servicio-consultas` is updated after
+each POST, PUT and DELETE operation.
 
 For deletions, pass both the employee id and the `contratoId` as a query
 parameter, e.g. `DELETE /api/saga/empleado-contrato/5?contratoId=10`.

--- a/docs/postman/consultas-saga-tests.postman_collection.json
+++ b/docs/postman/consultas-saga-tests.postman_collection.json
@@ -1,0 +1,246 @@
+{
+  "info": {
+    "name": "Servicio Consultas Saga Checks",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Crear empleado y contrato (SAGA)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","saga","empleado-contrato"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"empleado\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Perez\",\n    \"documento\": \"12345678\",\n    \"fechaNacimiento\": \"1990-01-01\"\n  },\n  \"contrato\": {\n    \"fechaInicio\": \"2023-01-01\",\n    \"fechaFin\": \"2023-12-31\",\n    \"tipo\": \"PLANTA\",\n    \"regimen\": \"TIEMPO_COMPLETO\",\n    \"salario\": 35000\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "const data = pm.response.json();",
+              "pm.collectionVariables.set('empleadoId', data.idEmpleadoCreado);",
+              "pm.collectionVariables.set('contratoId', data.idContratoCreado);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Empleado creado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","empleados","{{empleadoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Contrato creado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/contratos/{{contratoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","contratos","{{contratoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Actualizar empleado y contrato (SAGA)",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","saga","empleado-contrato","{{empleadoId}}"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"empleado\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Gomez\",\n    \"documento\": \"12345678\",\n    \"fechaNacimiento\": \"1990-01-01\"\n  },\n  \"contrato\": {\n    \"id\": {{contratoId}},\n    \"empleadoId\": {{empleadoId}},\n    \"fechaInicio\": \"2023-01-01\",\n    \"fechaFin\": \"2023-12-31\",\n    \"tipo\": \"PLANTA\",\n    \"regimen\": \"TIEMPO_COMPLETO\",\n    \"salario\": 35000\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Empleado actualizado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","empleados","{{empleadoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('apellido actualizado', function () {",
+              "    const emp = pm.response.json();",
+              "    pm.expect(emp.apellido).to.eql('Gomez');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Eliminar empleado y contrato (SAGA)",
+      "request": {
+        "method": "DELETE",
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}?contratoId={{contratoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","saga","empleado-contrato","{{empleadoId}}"],
+          "query": [
+            {
+              "key": "contratoId",
+              "value": "{{contratoId}}"
+            }
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Empleado eliminado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","empleados","{{empleadoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 404', function () {",
+              "    pm.response.to.have.status(404);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Contrato eliminado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/contratos/{{contratoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","contratos","{{contratoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 404', function () {",
+              "    pm.response.to.have.status(404);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a new Postman collection `consultas-saga-tests.postman_collection.json`
  verifying that servicio-consultas is updated after saga POST, PUT and DELETE
- mention the new collection in README

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851653b3fe88324a123aceb21d98e28