### PR TITLE
Fix Kafka deletion deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Ensure your local MariaDB instance is running before starting the services. Test
 Sample Postman collection files are provided under `docs/postman`. Import
 `rrhh-saga-tests.postman_collection.json` into Postman to try the SAGA
 create, update, delete and status flows via the `/api/saga/empleado-contrato`
-endpoints.
+endpoints. The file `consultas-saga-tests.postman_collection.json` contains
+additional requests that validate how `servicio-consultas` is updated after
+each POST, PUT and DELETE operation.
 
 For deletions, pass both the employee id and the `contratoId` as a query
 parameter, e.g. `DELETE /api/saga/empleado-contrato/5?contratoId=10`.

--- a/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/config/kafka/CommonKafkaConfig.java
+++ b/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/config/kafka/CommonKafkaConfig.java
@@ -62,57 +62,57 @@ public class CommonKafkaConfig {
     // Topics for domain events
     @Bean
     public NewTopic empleadoCreatedTopic() {
-        return new NewTopic("servicio-empleado.created", 3, (short) 1);
+        return new NewTopic("empleado.created", 3, (short) 1);
     }
 
     @Bean
     public NewTopic empleadoUpdatedTopic() {
-        return new NewTopic("servicio-empleado.updated", 3, (short) 1);
+        return new NewTopic("empleado.updated", 3, (short) 1);
     }
 
     @Bean
     public NewTopic empleadoDeletedTopic() {
-        return new NewTopic("servicio-empleado.deleted", 3, (short) 1);
+        return new NewTopic("empleado.deleted", 3, (short) 1);
     }
 
     @Bean
     public NewTopic contratoCreatedTopic() {
-        return new NewTopic("servicio-contrato.created", 3, (short) 1);
+        return new NewTopic("servicioContrato.contrato.created", 3, (short) 1);
     }
 
     @Bean
     public NewTopic contratoUpdatedTopic() {
-        return new NewTopic("servicio-contrato.updated", 3, (short) 1);
+        return new NewTopic("servicioContrato.contrato.updated", 3, (short) 1);
     }
 
     @Bean
     public NewTopic contratoDeletedTopic() {
-        return new NewTopic("servicio-contrato.deleted", 3, (short) 1);
+        return new NewTopic("servicioContrato.contrato.deleted", 3, (short) 1);
     }
 
     @Bean
     public NewTopic entrenamientoCreatedTopic() {
-        return new NewTopic("servicio-entrenamiento.created", 3, (short) 1);
+        return new NewTopic("servicioEntrenamiento.scheduled", 3, (short) 1);
     }
 
     @Bean
     public NewTopic entrenamientoUpdatedTopic() {
-        return new NewTopic("servicio-entrenamiento.updated", 3, (short) 1);
+        return new NewTopic("servicioEntrenamiento.updated", 3, (short) 1);
     }
 
     @Bean
     public NewTopic entrenamientoDeletedTopic() {
-        return new NewTopic("servicio-entrenamiento.deleted", 3, (short) 1);
+        return new NewTopic("servicioEntrenamiento.evaluated", 3, (short) 1);
     }
 
     @Bean
     public NewTopic nominaCreatedTopic() {
-        return new NewTopic("servicio-nomina.created", 3, (short) 1);
+        return new NewTopic("servicioNomina.nomina.generated", 3, (short) 1);
     }
 
     @Bean
     public NewTopic nominaDeletedTopic() {
-        return new NewTopic("servicio-nomina.deleted", 3, (short) 1);
+        return new NewTopic("servicioNomina.added", 3, (short) 1);
     }
 
     // Compensation topic

--- a/docs/postman/consultas-saga-tests.postman_collection.json
+++ b/docs/postman/consultas-saga-tests.postman_collection.json
@@ -1,0 +1,246 @@
+{
+  "info": {
+    "name": "Servicio Consultas Saga Checks",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Crear empleado y contrato (SAGA)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","saga","empleado-contrato"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"empleado\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Perez\",\n    \"documento\": \"12345678\",\n    \"fechaNacimiento\": \"1990-01-01\"\n  },\n  \"contrato\": {\n    \"fechaInicio\": \"2023-01-01\",\n    \"fechaFin\": \"2023-12-31\",\n    \"tipo\": \"PLANTA\",\n    \"regimen\": \"TIEMPO_COMPLETO\",\n    \"salario\": 35000\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "const data = pm.response.json();",
+              "pm.collectionVariables.set('empleadoId', data.idEmpleadoCreado);",
+              "pm.collectionVariables.set('contratoId', data.idContratoCreado);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Empleado creado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","empleados","{{empleadoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Contrato creado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/contratos/{{contratoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","contratos","{{contratoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Actualizar empleado y contrato (SAGA)",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","saga","empleado-contrato","{{empleadoId}}"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"empleado\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Gomez\",\n    \"documento\": \"12345678\",\n    \"fechaNacimiento\": \"1990-01-01\"\n  },\n  \"contrato\": {\n    \"id\": {{contratoId}},\n    \"empleadoId\": {{empleadoId}},\n    \"fechaInicio\": \"2023-01-01\",\n    \"fechaFin\": \"2023-12-31\",\n    \"tipo\": \"PLANTA\",\n    \"regimen\": \"TIEMPO_COMPLETO\",\n    \"salario\": 35000\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Empleado actualizado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","empleados","{{empleadoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('apellido actualizado', function () {",
+              "    const emp = pm.response.json();",
+              "    pm.expect(emp.apellido).to.eql('Gomez');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Eliminar empleado y contrato (SAGA)",
+      "request": {
+        "method": "DELETE",
+        "url": {
+          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}?contratoId={{contratoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","saga","empleado-contrato","{{empleadoId}}"],
+          "query": [
+            {
+              "key": "contratoId",
+              "value": "{{contratoId}}"
+            }
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Empleado eliminado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","empleados","{{empleadoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 404', function () {",
+              "    pm.response.to.have.status(404);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Contrato eliminado en consultas",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "http://localhost:8095/api/contratos/{{contratoId}}",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8095",
+          "path": ["api","contratos","{{contratoId}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status 404', function () {",
+              "    pm.response.to.have.status(404);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/evento/EmpleadoSyncListener.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/evento/EmpleadoSyncListener.java
@@ -24,7 +24,7 @@ public class EmpleadoSyncListener {
     }
 
     @KafkaListener(topics = "empleado.deleted")
-    public void onDeleted(EmpleadoRegistryDto dto) {
-        jdbc.update("DELETE FROM empleado_registry WHERE id=?", dto.getId());
+    public void onDeleted(Long id) {
+        jdbc.update("DELETE FROM empleado_registry WHERE id=?", id);
     }
 }

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/evento/EmpleadoSyncListener.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/evento/EmpleadoSyncListener.java
@@ -22,7 +22,7 @@ public class EmpleadoSyncListener {
                 dto.getLegajo(), dto.getNombre(), dto.getApellido(), dto.getId());
     }
     @KafkaListener(topics="empleado.deleted")
-    public void onDeleted(EmpleadoRegistryDto dto) {
-        jdbc.update("DELETE FROM employee_registry WHERE id=?", dto.getId());
+    public void onDeleted(Long id) {
+        jdbc.update("DELETE FROM employee_registry WHERE id=?", id);
     }
 }

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/evento/EmployeeSyncListener.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/evento/EmployeeSyncListener.java
@@ -25,7 +25,7 @@ public class EmployeeSyncListener {
     }
 
     @KafkaListener(topics = "empleado.deleted")
-    public void onDeleted(EmpleadoRegistryDto dto) {
-        jdbc.update("DELETE FROM empleado_registry WHERE id=?", dto.getId());
+    public void onDeleted(Long id) {
+        jdbc.update("DELETE FROM empleado_registry WHERE id=?", id);
     }
 }


### PR DESCRIPTION
## Summary
- update `EmpleadoSyncListener` classes to accept a Long id for `empleado.deleted` events
- add Postman collection for validating consultas updates from saga operations
- fix inconsistent Kafka topic names in `CommonKafkaConfig`

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851653b3fe88324a123aceb21d98e28