### PR TITLE
Fix saga fallback transitions

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/EmpleadoSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/EmpleadoSagaActions.java
@@ -76,10 +76,10 @@ public class EmpleadoSagaActions {
 
         StateMachine<Estados, Eventos> machine = context.getStateMachine();
         Message<Eventos> msgFb = MessageBuilder
-                .withPayload(Eventos.CB_REVERTIDO)
+                .withPayload(Eventos.FALLBACK_EMPLEADO)
                 .build();
         machine.sendEvent(msgFb);
-        log.info("[SAGA] Emitido CB_REVERTIDO");
+        log.info("[SAGA] Emitido FALLBACK_EMPLEADO");
     }
 
     /** Actualiza un empleado existente y emite EMPLEADO_ACTUALIZADO. */

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -285,7 +285,12 @@ public class SagaStateMachineConfig
                 .and()
                 .withExternal()
                 .source(Estados.CREAR_CONTRATO).target(Estados.REVERTIDA)
-                .event(Eventos.FALLBACK_CONTRATO);
+                .event(Eventos.FALLBACK_CONTRATO)
+
+                .and()
+                .withExternal()
+                .source(Estados.COMPENSAR_EMPLEADO).target(Estados.REVERTIDA)
+                .event(Eventos.COMPENSAR_EMPLEADO);
     }
 
     /** ⑪ Listener para trazas */

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/Eventos.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/Eventos.java
@@ -43,12 +43,9 @@ public enum Eventos {
     // 9) Compensar empleado (trigger para eliminar empleado)
     COMPENSAR_EMPLEADO,
 
-    // 10) CircuitBreaker de empleado se abrió → REVERTIR antes de intentar contrato
-    CB_REVERTIDO,
-
-    // 11) Señalar final exitoso (empleado+contrato creados)
+    // 10) Señalar final exitoso (empleado+contrato creados)
     FINALIZAR,
 
-    // 12) Evento de error general forzando camino a FALLIDA
+    // 11) Evento de error general forzando camino a FALLIDA
     ERROR
 }


### PR DESCRIPTION
## Summary
- send `FALLBACK_EMPLEADO` when the employee circuit breaker triggers
- remove unused `CB_REVERTIDO` event
- allow transition from `COMPENSAR_EMPLEADO` to `REVERTIDA`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685250e8e5748324b3e19478ae5b8ad5