### PR TITLE
Fix saga rollback on contract failure

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -279,12 +279,22 @@ public class SagaStateMachineConfig
 
                 .and()
                 .withExternal()
-                .source(Estados.CREAR_CONTRATO).target(Estados.FALLIDA)
+                .source(Estados.CREAR_CONTRATO).target(Estados.COMPENSAR_EMPLEADO)
                 .event(Eventos.CONTRATO_FALLIDO)
 
                 .and()
                 .withExternal()
-                .source(Estados.CREAR_CONTRATO).target(Estados.REVERTIDA)
+                .source(Estados.CREAR_CONTRATO).target(Estados.COMPENSAR_EMPLEADO)
+                .event(Eventos.FALLBACK_CONTRATO)
+
+                .and()
+                .withExternal()
+                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.COMPENSAR_EMPLEADO)
+                .event(Eventos.CONTRATO_FALLIDO)
+
+                .and()
+                .withExternal()
+                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.COMPENSAR_EMPLEADO)
                 .event(Eventos.FALLBACK_CONTRATO)
 
                 .and()

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/Estados.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/Estados.java
@@ -16,7 +16,7 @@ public enum Estados {
     ELIMINAR_EMPLEADO,    // Borrar empleado existente
     EMPLEADO_ELIMINADO,   // Empleado eliminado correctamente
     COMPENSAR_EMPLEADO,   // Estamos en rollback: se va a eliminar al empleado
-    REVERTIDA,            // Circuit Breaker de empleado se abrió (revertir sin intentar contrato)
+    REVERTIDA,            // Se revirtieron las acciones por fallo de empleado o contrato
     FALLIDA,              // Caso general de error irrecuperable (sin fallback)
     FINALIZADA            // Exito completo (empleado+contrato creados)
 }


### PR DESCRIPTION
## Summary
- allow rollback when contrato creation fails or circuit breaker triggers
- clarify `REVERTIDA` state meaning
- handle contract update failures

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852800d8ab8832495086b3493b4f302