### PR TITLE
Fix saga update rollback

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -274,12 +274,12 @@ public class SagaStateMachineConfig
 
                 .and()
                 .withExternal()
-                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.COMPENSAR_EMPLEADO)
+                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.REVERTIDA)
                 .event(Eventos.CONTRATO_FALLIDO)
 
                 .and()
                 .withExternal()
-                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.COMPENSAR_EMPLEADO)
+                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.REVERTIDA)
                 .event(Eventos.FALLBACK_CONTRATO)
 
                 .and()


### PR DESCRIPTION
## Summary
- stop deleting employees when contract update fails
- test transition when contract update fails

## Testing
- `./mvnw test -pl servicio-orquestador` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852d2a1a554832497238987af653d47