### PR TITLE
Fix kafka deserialization in contrato

### DIFF
--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -28,8 +28,8 @@ spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=grupo-servicio-contrato
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.consumer.properties.spring.json.trusted.packages=*
-
-
+spring.kafka.consumer.properties.spring.json.use.type.headers=false
 spring.kafka.consumer.properties.spring.json.value.default.type=ar.org.hospitalcuencaalta.servicio_contrato.web.dto.EmpleadoRegistryDto


### PR DESCRIPTION
## Summary
- use ErrorHandlingDeserializer for contrato Kafka listener
- ignore type headers so JsonDeserializer maps events to EmpleadoRegistryDto

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852dab994f88324978a684a9225c021