### PR TITLE
Log duplicate entry errors in contrato service

### DIFF
--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/evento/EmpleadoSyncListener.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/evento/EmpleadoSyncListener.java
@@ -1,11 +1,15 @@
 package ar.org.hospitalcuencaalta.servicio_contrato.evento;
 
 import ar.org.hospitalcuencaalta.servicio_contrato.web.dto.EmpleadoRegistryDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class EmpleadoSyncListener {
     @Autowired
@@ -13,18 +17,32 @@ public class EmpleadoSyncListener {
 
     @KafkaListener(topics = "empleado.created")
     public void onCreated(EmpleadoRegistryDto dto) {
-        jdbc.update("INSERT INTO empleado_registry(id, legajo, nombre, apellido) VALUES (?,?,?,?)",
-                dto.getId(), dto.getLegajo(), dto.getNombre(), dto.getApellido());
+        try {
+            jdbc.update("INSERT INTO empleado_registry(id, legajo, nombre, apellido) VALUES (?,?,?,?)",
+                    dto.getId(), dto.getLegajo(), dto.getNombre(), dto.getApellido());
+        } catch (DuplicateKeyException e) {
+            log.error("[EmpleadoSync] Clave duplicada al insertar empleado {}", dto.getId(), e);
+        } catch (DataAccessException e) {
+            log.error("[EmpleadoSync] Error al insertar empleado {}", dto.getId(), e);
+        }
     }
 
     @KafkaListener(topics = "empleado.updated")
     public void onUpdated(EmpleadoRegistryDto dto) {
-        jdbc.update("UPDATE empleado_registry SET legajo=?, nombre=?, apellido=? WHERE id=?",
-                dto.getLegajo(), dto.getNombre(), dto.getApellido(), dto.getId());
+        try {
+            jdbc.update("UPDATE empleado_registry SET legajo=?, nombre=?, apellido=? WHERE id=?",
+                    dto.getLegajo(), dto.getNombre(), dto.getApellido(), dto.getId());
+        } catch (DataAccessException e) {
+            log.error("[EmpleadoSync] Error al actualizar empleado {}", dto.getId(), e);
+        }
     }
 
     @KafkaListener(topics = "empleado.deleted")
     public void onDeleted(Long id) {
-        jdbc.update("DELETE FROM empleado_registry WHERE id=?", id);
+        try {
+            jdbc.update("DELETE FROM empleado_registry WHERE id=?", id);
+        } catch (DataAccessException e) {
+            log.error("[EmpleadoSync] Error al eliminar empleado {}", id, e);
+        }
     }
 }

--- a/servicio-contrato/src/main/resources/logback-spring.xml
+++ b/servicio-contrato/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<configuration>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/servicio-contrato.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/servicio-contrato.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- handle duplicate key and data access errors in `EmpleadoSyncListener`
- add logback configuration for file logging in `servicio-contrato`

## Testing
- `./mvnw -q -pl servicio-contrato -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852de238e3c8324a9d27fac994e9327