### PR TITLE
Refactor sendEvent usage

### DIFF
--- a/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/statemachine/EventosSM.java
+++ b/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/statemachine/EventosSM.java
@@ -1,0 +1,40 @@
+package ar.org.hospitalcuencaalta.comunes.statemachine;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateMachine;
+import reactor.core.publisher.Mono;
+
+/**
+ * Utilidad para enviar eventos a una {@link StateMachine} utilizando
+ * la variante reactiva recomendada en Spring StateMachine 4.x.
+ */
+public final class EventosSM {
+
+    private EventosSM() {
+        // Utilidad
+    }
+
+    /**
+     * Construye un {@link Message} con el evento recibido y lo envía
+     * de forma reactiva a la máquina de estados.
+     *
+     * @param machine máquina de estados destino
+     * @param evento  evento a despachar
+     * @param <S>     tipo de estado
+     * @param <E>     tipo de evento (enum)
+     */
+    public static <S, E extends Enum<E>> void enviar(StateMachine<S, E> machine,
+                                                     E evento) {
+        Message<E> msg = MessageBuilder.withPayload(evento).build();
+        enviar(machine, msg);
+    }
+
+    /**
+     * Envía un {@link Message} preconstruido de forma reactiva.
+     */
+    public static <S, E extends Enum<E>> void enviar(StateMachine<S, E> machine,
+                                                     Message<E> message) {
+        machine.sendEvent(Mono.just(message)).subscribe();
+    }
+}

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/CompensacionSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/CompensacionSagaActions.java
@@ -10,8 +10,7 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
+import ar.org.hospitalcuencaalta.comunes.statemachine.EventosSM;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.stereotype.Component;
@@ -68,10 +67,7 @@ public class CompensacionSagaActions {
             }
 
             // 4) Emitir COMPENSAR_EMPLEADO
-            Message<Eventos> msg = MessageBuilder
-                    .withPayload(Eventos.COMPENSAR_EMPLEADO)
-                    .build();
-            machine.sendEvent(msg);
+            EventosSM.enviar(machine, Eventos.COMPENSAR_EMPLEADO);
             log.info("[SAGA] Emitido COMPENSAR_EMPLEADO");
             return null;
         });

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/ContratoSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/ContratoSagaActions.java
@@ -10,6 +10,7 @@ import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import ar.org.hospitalcuencaalta.comunes.statemachine.EventosSM;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.StateContext;
@@ -61,7 +62,7 @@ public class ContratoSagaActions {
                         .setHeader("idContrato", idContrato)
                         .setHeader("idEmpleado", idEmpleado)
                         .build();
-                machine.sendEvent(msgCreado);
+                EventosSM.enviar(machine, msgCreado);
                 log.info("[SAGA] Emitido CONTRATO_CREADO id={}", idContrato);
             } catch (FeignException.BadRequest bad) {
                 log.warn("[SAGA] Datos inválidos al crear contrato para empleadoId={}, {}", idEmpleado, bad.contentUTF8());
@@ -70,13 +71,13 @@ public class ContratoSagaActions {
                 Message<Eventos> msgErr = MessageBuilder
                         .withPayload(Eventos.CONTRATO_FALLIDO)
                         .build();
-                machine.sendEvent(msgErr);
+                EventosSM.enviar(machine, msgErr);
             } catch (FeignException.Conflict conflict) {
                 log.warn("[SAGA] Contrato duplicado para empleadoId={}", idEmpleado);
                 Message<Eventos> msgErr = MessageBuilder
                         .withPayload(Eventos.CONTRATO_FALLIDO)
                         .build();
-                machine.sendEvent(msgErr);
+                EventosSM.enviar(machine, msgErr);
                 context.getExtendedState().getVariables()
                         .put("mensajeError", "Contrato duplicado");
             } catch (FeignException fe) {
@@ -84,7 +85,7 @@ public class ContratoSagaActions {
                 Message<Eventos> msgErr = MessageBuilder
                         .withPayload(Eventos.CONTRATO_FALLIDO)
                         .build();
-                machine.sendEvent(msgErr);
+                EventosSM.enviar(machine, msgErr);
             }
 
             return null;
@@ -110,7 +111,7 @@ public class ContratoSagaActions {
         Message<Eventos> msgFb = MessageBuilder
                 .withPayload(Eventos.FALLBACK_CONTRATO)
                 .build();
-        machine.sendEvent(msgFb);
+        EventosSM.enviar(machine, msgFb);
         log.info("[SAGA] Emitido FALLBACK_CONTRATO");
     }
 
@@ -134,18 +135,18 @@ public class ContratoSagaActions {
                 Message<Eventos> msg = MessageBuilder.withPayload(Eventos.CONTRATO_ACTUALIZADO)
                         .setHeader("idContrato", idContrato)
                         .build();
-                machine.sendEvent(msg);
+                EventosSM.enviar(machine, msg);
                 log.info("[SAGA] Emitido CONTRATO_ACTUALIZADO id={}", idContrato);
             } catch (FeignException.BadRequest bad) {
                 log.warn("[SAGA] Datos inválidos al actualizar contrato id={}, {}", idContrato, bad.contentUTF8());
                 context.getExtendedState().getVariables()
                         .put("mensajeError", "Campos obligatorios faltantes");
                 Message<Eventos> msgErr = MessageBuilder.withPayload(Eventos.CONTRATO_FALLIDO).build();
-                machine.sendEvent(msgErr);
+                EventosSM.enviar(machine, msgErr);
             } catch (FeignException fe) {
                 log.error("[SAGA] Error al actualizar contrato id={}: {}", idContrato, fe.contentUTF8());
                 Message<Eventos> msgErr = MessageBuilder.withPayload(Eventos.CONTRATO_FALLIDO).build();
-                machine.sendEvent(msgErr);
+                EventosSM.enviar(machine, msgErr);
             }
 
             return null;
@@ -170,7 +171,7 @@ public class ContratoSagaActions {
 
         StateMachine<Estados, Eventos> machine = context.getStateMachine();
         Message<Eventos> msgFb = MessageBuilder.withPayload(Eventos.FALLBACK_CONTRATO).build();
-        machine.sendEvent(msgFb);
+        EventosSM.enviar(machine, msgFb);
         log.info("[SAGA] Emitido FALLBACK_CONTRATO");
     }
 
@@ -185,7 +186,7 @@ public class ContratoSagaActions {
             Message<Eventos> msg = MessageBuilder.withPayload(Eventos.CONTRATO_ELIMINADO)
                     .setHeader("idContrato", idContrato)
                     .build();
-            machine.sendEvent(msg);
+            EventosSM.enviar(machine, msg);
             log.info("[SAGA] Emitido CONTRATO_ELIMINADO id={}", idContrato);
             return null;
         });

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/EmpleadoSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/EmpleadoSagaActions.java
@@ -9,6 +9,7 @@ import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import ar.org.hospitalcuencaalta.comunes.statemachine.EventosSM;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.StateContext;
@@ -44,7 +45,7 @@ public class EmpleadoSagaActions {
                 Message<Eventos> msgExists = MessageBuilder
                         .withPayload(Eventos.EMPLEADO_EXISTE)
                         .build();
-                machine.sendEvent(msgExists);
+                EventosSM.enviar(machine, msgExists);
                 log.info("[SAGA] Emitido EMPLEADO_EXISTE");
                 return null;
             } catch (FeignException.NotFound nf) {
@@ -67,7 +68,7 @@ public class EmpleadoSagaActions {
                     .withPayload(Eventos.EMPLEADO_CREADO)
                     .setHeader("idEmpleado", idGenerado)
                     .build();
-            machine.sendEvent(msgCreado);
+            EventosSM.enviar(machine, msgCreado);
             log.info("[SAGA] Emitido EMPLEADO_CREADO id={}", idGenerado);
 
             return null;
@@ -83,7 +84,7 @@ public class EmpleadoSagaActions {
         Message<Eventos> msgFb = MessageBuilder
                 .withPayload(Eventos.FALLBACK_EMPLEADO)
                 .build();
-        machine.sendEvent(msgFb);
+        EventosSM.enviar(machine, msgFb);
         log.info("[SAGA] Emitido FALLBACK_EMPLEADO");
     }
 
@@ -101,7 +102,7 @@ public class EmpleadoSagaActions {
             Message<Eventos> msg = MessageBuilder.withPayload(Eventos.EMPLEADO_ACTUALIZADO)
                     .setHeader("idEmpleado", id)
                     .build();
-            machine.sendEvent(msg);
+            EventosSM.enviar(machine, msg);
             log.info("[SAGA] Emitido EMPLEADO_ACTUALIZADO id={}", id);
             return null;
         });
@@ -118,7 +119,7 @@ public class EmpleadoSagaActions {
             Message<Eventos> msg = MessageBuilder.withPayload(Eventos.EMPLEADO_ELIMINADO)
                     .setHeader("idEmpleado", id)
                     .build();
-            machine.sendEvent(msg);
+            EventosSM.enviar(machine, msg);
             log.info("[SAGA] Emitido EMPLEADO_ELIMINADO id={}", id);
             return null;
         });

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -10,8 +10,8 @@ import ar.org.hospitalcuencaalta.servicio_orquestador.servicio.SagaStateService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
+import ar.org.hospitalcuencaalta.comunes.statemachine.EventosSM;
+
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.config.EnableStateMachineFactory;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
@@ -22,7 +22,6 @@ import org.springframework.statemachine.listener.StateMachineListener;
 import org.springframework.statemachine.listener.StateMachineListenerAdapter;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.transition.Transition;
-import reactor.core.publisher.Mono;
 
 import java.util.EnumSet;
 
@@ -78,11 +77,7 @@ public class SagaStateMachineConfig
                 // ⑥ Al entrar en EMPLEADO_CREADO disparamos SOLICITAR_CREAR_CONTRATO
                 .stateEntry(Estados.EMPLEADO_CREADO, context -> {
                     StateMachine<Estados, Eventos> machine = context.getStateMachine();
-                    Message<Eventos> msg = MessageBuilder
-                            .withPayload(Eventos.SOLICITAR_CREAR_CONTRATO)
-                            .build();
-                    // En 4.0 sendEvent(E) está deprecado; usamos la variante reactiva
-                    machine.sendEvent(Mono.just(msg)).subscribe();
+                    EventosSM.enviar(machine, Eventos.SOLICITAR_CREAR_CONTRATO);
                     sagaStateService.save(machine);
                     log.info("[SAGA] {} enviado", Eventos.SOLICITAR_CREAR_CONTRATO);
                 })
@@ -101,10 +96,7 @@ public class SagaStateMachineConfig
 
                 .stateEntry(Estados.EMPLEADO_ACTUALIZADO, context -> {
                     StateMachine<Estados, Eventos> machine = context.getStateMachine();
-                    Message<Eventos> msg = MessageBuilder
-                            .withPayload(Eventos.SOLICITAR_ACTUALIZAR_CONTRATO)
-                            .build();
-                    machine.sendEvent(Mono.just(msg)).subscribe();
+                    EventosSM.enviar(machine, Eventos.SOLICITAR_ACTUALIZAR_CONTRATO);
                     sagaStateService.save(machine);
                     log.info("[SAGA] {} enviado", Eventos.SOLICITAR_ACTUALIZAR_CONTRATO);
                 })
@@ -122,10 +114,7 @@ public class SagaStateMachineConfig
 
                 .stateEntry(Estados.CONTRATO_ELIMINADO, context -> {
                     StateMachine<Estados, Eventos> machine = context.getStateMachine();
-                    Message<Eventos> msg = MessageBuilder
-                            .withPayload(Eventos.SOLICITAR_ELIMINAR_EMPLEADO)
-                            .build();
-                    machine.sendEvent(Mono.just(msg)).subscribe();
+                    EventosSM.enviar(machine, Eventos.SOLICITAR_ELIMINAR_EMPLEADO);
                     sagaStateService.save(machine);
                     log.info("[SAGA] {} enviado", Eventos.SOLICITAR_ELIMINAR_EMPLEADO);
                 })
@@ -137,10 +126,7 @@ public class SagaStateMachineConfig
 
                 .stateEntry(Estados.EMPLEADO_ELIMINADO, context -> {
                     StateMachine<Estados, Eventos> sm = context.getStateMachine();
-                    Message<Eventos> msg = MessageBuilder
-                            .withPayload(Eventos.FINALIZAR)
-                            .build();
-                    sm.sendEvent(Mono.just(msg)).subscribe();
+                    EventosSM.enviar(sm, Eventos.FINALIZAR);
                     sagaStateService.save(sm);
                     log.info("[SAGA] {} enviado", Eventos.FINALIZAR);
                 })
@@ -148,10 +134,7 @@ public class SagaStateMachineConfig
                 // ⑧ Al entrar en CONTRATO_CREADO enviamos FINALIZAR
                 .stateEntry(Estados.CONTRATO_CREADO, context -> {
                     StateMachine<Estados, Eventos> sm = context.getStateMachine();
-                    Message<Eventos> msg = MessageBuilder
-                            .withPayload(Eventos.FINALIZAR)
-                            .build();
-                    sm.sendEvent(Mono.just(msg)).subscribe();
+                    EventosSM.enviar(sm, Eventos.FINALIZAR);
                     sagaStateService.save(sm);
                     log.info("[SAGA] {} enviado", Eventos.FINALIZAR);
                 })

--- a/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/SagaStateMachineConfigTest.java
+++ b/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/SagaStateMachineConfigTest.java
@@ -11,14 +11,12 @@ import ar.org.hospitalcuencaalta.servicio_orquestador.servicio.SagaStateService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
+import ar.org.hospitalcuencaalta.comunes.statemachine.EventosSM;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import reactor.core.publisher.Mono;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.atLeastOnce;
@@ -42,10 +40,9 @@ class SagaStateMachineConfigTest {
         StateMachine<Estados, Eventos> sm = stateMachineFactory.getStateMachine();
         sm.startReactively().block();
 
-        Message<Eventos> startMsg = MessageBuilder.withPayload(Eventos.SOLICITAR_CREAR_EMPLEADO).build();
-        sm.sendEvent(Mono.just(startMsg)).blockLast();
-        sm.sendEvent(Mono.just(MessageBuilder.withPayload(Eventos.EMPLEADO_CREADO).build())).blockLast();
-        sm.sendEvent(Mono.just(MessageBuilder.withPayload(Eventos.CONTRATO_CREADO).build())).blockLast();
+        EventosSM.enviar(sm, Eventos.SOLICITAR_CREAR_EMPLEADO);
+        EventosSM.enviar(sm, Eventos.EMPLEADO_CREADO);
+        EventosSM.enviar(sm, Eventos.CONTRATO_CREADO);
 
         assertEquals(Estados.FINALIZADA, sm.getState().getId());
         verify(sagaStateService, atLeastOnce()).save(sm);
@@ -57,18 +54,10 @@ class SagaStateMachineConfigTest {
         sm.startReactively().block();
 
         // Simular camino de actualización hasta el fallo del contrato
-        sm.sendEvent(Mono.just(MessageBuilder
-                .withPayload(Eventos.SOLICITAR_ACTUALIZAR_EMPLEADO)
-                .build())).blockLast();
-        sm.sendEvent(Mono.just(MessageBuilder
-                .withPayload(Eventos.EMPLEADO_ACTUALIZADO)
-                .build())).blockLast();
-        sm.sendEvent(Mono.just(MessageBuilder
-                .withPayload(Eventos.SOLICITAR_ACTUALIZAR_CONTRATO)
-                .build())).blockLast();
-        sm.sendEvent(Mono.just(MessageBuilder
-                .withPayload(Eventos.CONTRATO_FALLIDO)
-                .build())).blockLast();
+        EventosSM.enviar(sm, Eventos.SOLICITAR_ACTUALIZAR_EMPLEADO);
+        EventosSM.enviar(sm, Eventos.EMPLEADO_ACTUALIZADO);
+        EventosSM.enviar(sm, Eventos.SOLICITAR_ACTUALIZAR_CONTRATO);
+        EventosSM.enviar(sm, Eventos.CONTRATO_FALLIDO);
 
         assertEquals(Estados.REVERTIDA, sm.getState().getId());
         verify(sagaStateService, atLeastOnce()).save(sm);


### PR DESCRIPTION
## Summary
- extend `EventosSM` to send pre-built messages
- refactor actions and config to use `EventosSM`
- update state machine test to use the helper

## Testing
- `./mvnw -q -pl servicio-orquestador -am test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68551e72b96483249943a4ab8183c6e5