### PR TITLE
Handle employee creation errors without rollback

### DIFF
--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/EmpleadoService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/EmpleadoService.java
@@ -21,11 +21,15 @@ public class EmpleadoService {
     private final EmpleadoEventPublisher publisher;
 
     public EmpleadoDto create(EmpleadoDto dto) {
-        Empleado entidad = mapper.toEntity(dto);
-        Empleado guardado = repo.save(entidad);
-        EmpleadoDto out = mapper.toDto(guardado);
-        publisher.publishCreated(out);
-        return out;
+        try {
+            Empleado entidad = mapper.toEntity(dto);
+            Empleado guardado = repo.save(entidad);
+            EmpleadoDto out = mapper.toDto(guardado);
+            publisher.publishCreated(out);
+            return out;
+        } catch (Exception ex) {
+            throw new RuntimeException("Error al persistir empleado", ex);
+        }
     }
 
     public List<EmpleadoDto> findAll() {

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -242,8 +242,8 @@ public class SagaStateMachineConfig
 
                 .and()
                 .withExternal()
-                .source(Estados.CREAR_EMPLEADO).target(Estados.COMPENSAR_EMPLEADO)
-                .event(Eventos.FALLBACK_EMPLEADO)
+                .source(Estados.CREAR_EMPLEADO).target(Estados.FALLIDA)
+                .event(Eventos.EMPLEADO_FALLIDO)
 
                 .and()
                 .withExternal()

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/Eventos.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/modelo/Eventos.java
@@ -13,8 +13,8 @@ public enum Eventos {
     // 3) Empleado creado exitosamente
     EMPLEADO_CREADO,
 
-    // 4) Fallback de cliente de empleado (CircuitBreaker atrapado)
-    FALLBACK_EMPLEADO,
+    // 4) Falló la creación del empleado y se desconoce si se persistió
+    EMPLEADO_FALLIDO,
 
     // 5) Iniciar creación del contrato (se genera tras EMPLEADO_CREADO)
     SOLICITAR_CREAR_CONTRATO,


### PR DESCRIPTION
## Summary
- surface new `EMPLEADO_FALLIDO` event
- emit that event when employee creation fails
- transition to `FALLIDA` on employee failure
- wrap persistence layer in `EmpleadoService` with error handling

## Testing
- `./mvnw -q -pl servicio-orquestador,servicio-empleado -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857e23b3a1883248c9e1b8a5c12f3f2