### PR TITLE
Gestión de errores en SAGA de contrato

### DIFF
--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/servicio/ContratoService.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/servicio/ContratoService.java
@@ -56,7 +56,12 @@ public class ContratoService {
                 .empleadoId(dto.getEmpleadoId())
                 .build();
 
-        ContratoLaboral guardado = repo.save(entidad);
+        ContratoLaboral guardado;
+        try {
+            guardado = repo.save(entidad);
+        } catch (Exception ex) {
+            throw new RuntimeException("Error al persistir contrato", ex);
+        }
 
         // 3) Devolver DTO con id generado
         return ContratoLaboralDto.builder()

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/ContratoSagaActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/ContratoSagaActions.java
@@ -89,6 +89,15 @@ public class ContratoSagaActions {
                         .withPayload(Eventos.CONTRATO_FALLIDO)
                         .build();
                 EventosSM.enviar(machine, msgErr);
+            } catch (Exception ex) {
+                log.error("[SAGA] Error inesperado al crear contrato", ex);
+                context.getExtendedState().getVariables().put(
+                        "mensajeError",
+                        "No se puede crear el contrato debido a un error inesperado");
+                Message<Eventos> msgErr = MessageBuilder
+                        .withPayload(Eventos.CONTRATO_FALLIDO)
+                        .build();
+                EventosSM.enviar(machine, msgErr);
             }
 
             return null;
@@ -157,6 +166,13 @@ public class ContratoSagaActions {
                         "No se puede actualizar el contrato porque el servicio no está disponible");
                 Message<Eventos> msgErr = MessageBuilder.withPayload(Eventos.CONTRATO_FALLIDO).build();
                 EventosSM.enviar(machine, msgErr);
+            } catch (Exception ex) {
+                log.error("[SAGA] Error inesperado al actualizar contrato", ex);
+                context.getExtendedState().getVariables().put(
+                        "mensajeError",
+                        "No se puede actualizar el contrato debido a un error inesperado");
+                Message<Eventos> msgErr = MessageBuilder.withPayload(Eventos.CONTRATO_FALLIDO).build();
+                EventosSM.enviar(machine, msgErr);
             }
 
             return null;
@@ -195,13 +211,30 @@ public class ContratoSagaActions {
             Long idContrato = context.getExtendedState().get("idContrato", Long.class);
             StateMachine<Estados, Eventos> machine = context.getStateMachine();
 
-            contratoClient.delete(idContrato);
+            try {
+                contratoClient.delete(idContrato);
 
-            Message<Eventos> msg = MessageBuilder.withPayload(Eventos.CONTRATO_ELIMINADO)
-                    .setHeader("idContrato", idContrato)
-                    .build();
-            EventosSM.enviar(machine, msg);
-            log.info("[SAGA] Emitido CONTRATO_ELIMINADO id={}", idContrato);
+                Message<Eventos> msg = MessageBuilder.withPayload(Eventos.CONTRATO_ELIMINADO)
+                        .setHeader("idContrato", idContrato)
+                        .build();
+                EventosSM.enviar(machine, msg);
+                log.info("[SAGA] Emitido CONTRATO_ELIMINADO id={}", idContrato);
+            } catch (FeignException fe) {
+                log.error("[SAGA] Error al eliminar contrato id={}: {}", idContrato, fe.contentUTF8());
+                context.getExtendedState().getVariables().put(
+                        "mensajeError",
+                        "No se puede eliminar el contrato porque el servicio no está disponible");
+                Message<Eventos> msgErr = MessageBuilder.withPayload(Eventos.CONTRATO_FALLIDO).build();
+                EventosSM.enviar(machine, msgErr);
+            } catch (Exception ex) {
+                log.error("[SAGA] Error inesperado al eliminar contrato", ex);
+                context.getExtendedState().getVariables().put(
+                        "mensajeError",
+                        "No se puede eliminar el contrato debido a un error inesperado");
+                Message<Eventos> msgErr = MessageBuilder.withPayload(Eventos.CONTRATO_FALLIDO).build();
+                EventosSM.enviar(machine, msgErr);
+            }
+
             return null;
         });
     }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/SagaStateMachineConfig.java
@@ -221,6 +221,11 @@ public class SagaStateMachineConfig
 
                 .and()
                 .withExternal()
+                .source(Estados.ELIMINAR_CONTRATO).target(Estados.FALLIDA)
+                .event(Eventos.CONTRATO_FALLIDO)
+
+                .and()
+                .withExternal()
                 .source(Estados.CONTRATO_ELIMINADO).target(Estados.ELIMINAR_EMPLEADO)
                 .event(Eventos.SOLICITAR_ELIMINAR_EMPLEADO)
 
@@ -228,6 +233,11 @@ public class SagaStateMachineConfig
                 .withExternal()
                 .source(Estados.ELIMINAR_EMPLEADO).target(Estados.EMPLEADO_ELIMINADO)
                 .event(Eventos.EMPLEADO_ELIMINADO)
+
+                .and()
+                .withExternal()
+                .source(Estados.ELIMINAR_EMPLEADO).target(Estados.FALLIDA)
+                .event(Eventos.EMPLEADO_FALLIDO)
 
                 .and()
                 .withExternal()
@@ -257,12 +267,17 @@ public class SagaStateMachineConfig
 
                 .and()
                 .withExternal()
-                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.REVERTIDA)
+                .source(Estados.ACTUALIZAR_EMPLEADO).target(Estados.FALLIDA)
+                .event(Eventos.EMPLEADO_FALLIDO)
+
+                .and()
+                .withExternal()
+                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.FALLIDA)
                 .event(Eventos.CONTRATO_FALLIDO)
 
                 .and()
                 .withExternal()
-                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.REVERTIDA)
+                .source(Estados.ACTUALIZAR_CONTRATO).target(Estados.FALLIDA)
                 .event(Eventos.FALLBACK_CONTRATO)
 
                 .and()


### PR DESCRIPTION
## Summary
- manage persistence errors when saving contracts
- send error events from contract saga actions
- propagate errors in employee saga update and delete
- route update/delete failures to `FALLIDA` state

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857e8366c4c8324a38a911daf965762