### PR TITLE
Fix duplicate employee events in contract service

### DIFF
--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/evento/EmpleadoSyncListener.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/evento/EmpleadoSyncListener.java
@@ -18,7 +18,9 @@ public class EmpleadoSyncListener {
     @KafkaListener(topics = "empleado.created")
     public void onCreated(EmpleadoRegistryDto dto) {
         try {
-            jdbc.update("INSERT INTO empleado_registry(id, legajo, nombre, apellido) VALUES (?,?,?,?)",
+            jdbc.update(
+                    "INSERT INTO empleado_registry(id, legajo, nombre, apellido) VALUES (?,?,?,?) " +
+                    "ON DUPLICATE KEY UPDATE legajo=VALUES(legajo), nombre=VALUES(nombre), apellido=VALUES(apellido)",
                     dto.getId(), dto.getLegajo(), dto.getNombre(), dto.getApellido());
         } catch (DuplicateKeyException e) {
             log.error("[EmpleadoSync] Clave duplicada al insertar empleado {}", dto.getId(), e);


### PR DESCRIPTION
## Summary
- handle duplicate employee events with SQL upsert

## Testing
- `mvnw` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857ee8a67208324aece71da1ee895ae