### PR TITLE
Fix MapStruct mappings for training service

### DIFF
--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/web/mapeos/CapacitacionMapper.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/web/mapeos/CapacitacionMapper.java
@@ -9,6 +9,18 @@ import org.mapstruct.Mapper;
  */
 @Mapper(componentModel = "spring")
 public interface CapacitacionMapper {
+
+    /**
+     * Entidad {@link Capacitacion} -> DTO. Sólo se expone el identificador
+     * del empleado asociado.
+     */
+    @Mapping(source = "empleado.id", target = "empleadoId")
     CapacitacionDto toDto(Capacitacion entity);
+
+    /**
+     * DTO -> Entidad {@link Capacitacion}. Se establece únicamente el id del
+     * empleado a través de su relación.
+     */
+    @Mapping(target = "empleado.id", source = "empleadoId")
     Capacitacion toEntity(CapacitacionDto dto);
 }

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/web/mapeos/EvaluacionMapper.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/web/mapeos/EvaluacionMapper.java
@@ -11,13 +11,26 @@ import org.mapstruct.Mappings;
  */
 @Mapper(componentModel = "spring", uses = YearMonthMapper.class)
 public interface EvaluacionMapper {
+
+    /**
+     * Entidad -> DTO. Se utilizan mapeos explícitos para las relaciones
+     * con el empleado evaluado y el evaluador.
+     */
     @Mappings({
-            @Mapping(source = "periodo", target = "periodo")
+            @Mapping(source = "periodo", target = "periodo"),
+            @Mapping(source = "empleado.id", target = "empleadoId"),
+            @Mapping(source = "evaluador.id", target = "evaluadorId")
     })
     EvaluacionDto toDto(EvaluacionDesempeno entity);
 
+    /**
+     * DTO -> Entidad. Solo seteamos los identificadores dentro de las
+     * relaciones correspondientes.
+     */
     @Mappings({
-            @Mapping(source = "periodo", target = "periodo")
+            @Mapping(source = "periodo", target = "periodo"),
+            @Mapping(target = "empleado.id", source = "empleadoId"),
+            @Mapping(target = "evaluador.id", source = "evaluadorId")
     })
     EvaluacionDesempeno toEntity(EvaluacionDto dto);
 }


### PR DESCRIPTION
## Summary
- map `empleadoId` in `CapacitacionMapper`
- map `empleadoId` and `evaluadorId` in `EvaluacionMapper`

## Testing
- `./mvnw -o -pl servicio-entrenamiento -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68591f101b8083248ad1ab242c28b375