### PR TITLE
Agregar pruebas de CapacitacionController

### DIFF
--- a/servicio-entrenamiento/pom.xml
+++ b/servicio-entrenamiento/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>

--- a/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/CapacitacionControllerIntegrationTest.java
+++ b/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/CapacitacionControllerIntegrationTest.java
@@ -1,0 +1,87 @@
+package ar.org.hospitalcuencaalta.servicio_entrenamiento.controlador;
+
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.modelo.Capacitacion;
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.repositorio.CapacitacionRepository;
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.modelo.EmpleadoRegistry;
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.repositorio.EmpleadoRegistryRepository;
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.CapacitacionDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:entrenamiento;DB_CLOSE_DELAY=-1",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.liquibase.enabled=false",
+        "eureka.client.enabled=false",
+        "spring.kafka.bootstrap-servers=localhost:9092",
+        "spring.kafka.consumer.group-id=test",
+        "spring.kafka.listener.auto-startup=false"
+})
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class CapacitacionControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CapacitacionRepository repo;
+
+    @Autowired
+    private EmpleadoRegistryRepository empleadoRepo;
+
+    @MockitoBean
+    private KafkaTemplate<String, Object> kafka;
+
+    @Test
+    void crearCapacitacion_debePersistirEnBDyPublicarEvento() throws Exception {
+        EmpleadoRegistry empleado = EmpleadoRegistry.builder()
+                .id(1L)
+                .legajo("A1")
+                .nombre("Juan")
+                .apellido("Perez")
+                .build();
+        empleadoRepo.save(empleado);
+
+        CapacitacionDto dto = CapacitacionDto.builder()
+                .nombreCurso("Curso Java")
+                .institucion("UBA")
+                .estado("planificada")
+                .empleadoId(empleado.getId())
+                .build();
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/api/capacitaciones")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+
+        assertThat(repo.count()).isEqualTo(1);
+        Capacitacion entidad = repo.findAll().get(0);
+        assertThat(entidad.getNombreCurso()).isEqualTo("Curso Java");
+        assertThat(entidad.getEmpleado().getId()).isEqualTo(empleado.getId());
+
+        verify(kafka, times(1)).send(eq("servicioEntrenamiento.scheduled"), any());
+    }
+}

--- a/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/CapacitacionControllerWebSliceTest.java
+++ b/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/CapacitacionControllerWebSliceTest.java
@@ -1,0 +1,78 @@
+package ar.org.hospitalcuencaalta.servicio_entrenamiento.controlador;
+
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.servicio.CapacitacionService;
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.CapacitacionDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.CapacitacionDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = CapacitacionController.class, properties = "eureka.client.enabled=false")
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class CapacitacionControllerWebSliceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CapacitacionService service;
+
+    @Test
+    void crearCapacitacion_debeRetornarDto() throws Exception {
+        CapacitacionDto dto = CapacitacionDto.builder().id(1L).nombreCurso("Java").build();
+        when(service.create(any(CapacitacionDto.class))).thenReturn(dto);
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/api/capacitaciones")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(content().json(json));
+
+        verify(service, times(1)).create(any(CapacitacionDto.class));
+    }
+
+    @Test
+    void listarCapacitaciones_debeRetornarLista() throws Exception {
+        List<CapacitacionDto> lista = List.of(
+                CapacitacionDto.builder().id(1L).build(),
+                CapacitacionDto.builder().id(2L).build()
+        );
+        when(service.findAll()).thenReturn(lista);
+        String esperado = objectMapper.writeValueAsString(lista);
+
+        mockMvc.perform(get("/api/capacitaciones"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(esperado));
+    }
+
+    @Test
+    void obtenerDetalle_debeUsarServicio() throws Exception {
+        CapacitacionDetalleDto detalle = CapacitacionDetalleDto.builder().id(1L).build();
+        when(service.getDetalle(1L)).thenReturn(detalle);
+        String esperado = objectMapper.writeValueAsString(detalle);
+
+        mockMvc.perform(get("/api/capacitaciones/{id}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(content().json(esperado));
+
+        verify(service, times(1)).getDetalle(1L);
+    }
+}


### PR DESCRIPTION
## Resumen
- se agrega una prueba de integración para `CapacitacionController`
- se agrega una prueba tipo web slice para el mismo controlador
- se agrega dependencia de H2 en `servicio-entrenamiento` para poder ejecutar pruebas
- se deshabilita Eureka en ambas pruebas para evitar conexiones de red durante la inicialización
- se corrige la prueba de integración registrando previamente un empleado

## Testing
- `./mvnw -q -pl servicio-entrenamiento -am test` *(falló por falta de acceso a internet)*

------
https://chatgpt.com/codex/tasks/task_e_685924b3585883248342b67cc3d8757c