### PR TITLE
Reparar la ruta del punto final del actuador del disyuntor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Use `GET /api/saga/empleado-contrato/{sagaId}` to inspect a saga's state.
 To check if the circuit breaker for employee creation opens, make several failing
 requests (for instance by stopping `servicio-empleado`) and then send a `GET`
 
-request to `http://localhost:8095/actuator/resilience4j/circuitbreakers/crearEmpleadoCB?includeState=true`.
+request to `http://localhost:8095/actuator/circuitbreakers/crearEmpleadoCB?includeState=true`.
 
 The `Estado Circuit Breaker crearEmpleadoCB` request in the Postman collection
 expects the breaker state to be `OPEN`.

--- a/docs/postman/rrhh-saga-tests.postman_collection.json
+++ b/docs/postman/rrhh-saga-tests.postman_collection.json
@@ -196,7 +196,7 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/actuator/resilience4j/circuitbreakers/crearEmpleadoCB?includeState=true",
+          "raw": "http://localhost:8095/actuator/circuitbreakers/crearEmpleadoCB?includeState=true",
           "protocol": "http",
           "host": [
             "localhost"
@@ -204,7 +204,6 @@
           "port": "8095",
           "path": [
             "actuator",
-            "resilience4j",
             "circuitbreakers",
             "crearEmpleadoCB"
           ],

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -122,7 +122,10 @@ resilience4j.bulkhead.instances.compensacionCB.baseConfig=default
 ############################################################
 # 6) Actuator / Metrics / Health Checks
 ############################################################
-management.endpoints.web.exposure.include=health,info,metrics,prometheus,loggers,httptrace,env,beans,resilience4j.circuitbreakers,resilience4j.ratelimiters,resilience4j.bulkheads
+# Actuator no utiliza el prefijo "resilience4j." para los endpoints a partir de
+# Spring Boot 3.x. Se corrige la lista para exponer correctamente los
+# CircuitBreakers, RateLimiters y Bulkheads.
+management.endpoints.web.exposure.include=health,info,metrics,prometheus,loggers,httptrace,env,beans,circuitbreakers,ratelimiters,bulkheads
 
 
 management.endpoint.health.show-details=always


### PR DESCRIPTION
## Summary
- expose circuit breaker actuator endpoints with the correct names
- update README and Postman collection with the right actuator path

## Testing
- `./mvnw -q test -DskipTests` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5747be4832496caefa05ab04461