### PR TITLE
Agregar puntos finales de actuador explícitos de Resilience4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ To check if the circuit breaker for employee creation opens, make several failin
 requests (for instance by stopping `servicio-empleado`) and then send a `GET`
 
 request to `http://localhost:8095/actuator/resilience4j/circuitbreakers/crearEmpleadoCB?includeState=true`.
+If the endpoint returns *405 Method Not Allowed*, verify that the
+`management.endpoints.web.exposure.include` list contains `resilience4j.circuitbreakers`
+and that the `management.endpoint.circuitbreakers.enabled` property is set to
+`true` in
+`servicio-orquestador/src/main/resources/application.properties` so the
+actuator endpoint is available. The `Resilience4jEndpointConfig` class inside
+`servicio-orquestador` registers the actuator beans (`CircuitBreakerEndpoint`,
+`RateLimiterEndpoint`, etc.) when auto-configuration is not triggered.
 
 The `Estado Circuit Breaker crearEmpleadoCB` request in the Postman collection
 expects the breaker state to be `OPEN`.

--- a/servicio-orquestador/pom.xml
+++ b/servicio-orquestador/pom.xml
@@ -41,6 +41,11 @@
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-all</artifactId>
         </dependency>
+        <!-- Actuator endpoints for Resilience4j components -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+        </dependency>
         <!-- Métricas y Actuator -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/Resilience4jEndpointConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/Resilience4jEndpointConfig.java
@@ -1,0 +1,55 @@
+package ar.org.hospitalcuencaalta.servicio_orquestador.config;
+
+import io.github.resilience4j.bulkhead.BulkheadRegistry;
+import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
+import io.github.resilience4j.bulkhead.monitoring.endpoint.BulkheadEndpoint;
+import io.github.resilience4j.bulkhead.monitoring.endpoint.ThreadPoolBulkheadEndpoint;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.circuitbreaker.monitoring.endpoint.CircuitBreakerEndpoint;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.monitoring.endpoint.RateLimiterEndpoint;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.github.resilience4j.retry.monitoring.endpoint.RetryEndpoint;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import io.github.resilience4j.timelimiter.monitoring.endpoint.TimeLimiterEndpoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers Resilience4j actuator endpoints when auto-configuration is not
+ * activated. These beans expose circuit breakers, rate limiters, bulkheads and
+ * other resilience components through Spring Boot Actuator.
+ */
+@Configuration
+public class Resilience4jEndpointConfig {
+
+    @Bean
+    public CircuitBreakerEndpoint circuitBreakerEndpoint(CircuitBreakerRegistry registry) {
+        return new CircuitBreakerEndpoint(registry);
+    }
+
+    @Bean
+    public RateLimiterEndpoint rateLimiterEndpoint(RateLimiterRegistry registry) {
+        return new RateLimiterEndpoint(registry);
+    }
+
+    @Bean
+    public BulkheadEndpoint bulkheadEndpoint(BulkheadRegistry registry) {
+        return new BulkheadEndpoint(registry);
+    }
+
+    @Bean
+    public ThreadPoolBulkheadEndpoint threadPoolBulkheadEndpoint(ThreadPoolBulkheadRegistry registry) {
+        return new ThreadPoolBulkheadEndpoint(registry);
+    }
+
+    @Bean
+    public RetryEndpoint retryEndpoint(RetryRegistry registry) {
+        return new RetryEndpoint(registry);
+    }
+
+    @Bean
+    public TimeLimiterEndpoint timeLimiterEndpoint(TimeLimiterRegistry registry) {
+        return new TimeLimiterEndpoint(registry);
+    }
+}

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -122,7 +122,16 @@ resilience4j.bulkhead.instances.compensacionCB.baseConfig=default
 ############################################################
 # 6) Actuator / Metrics / Health Checks
 ############################################################
-management.endpoints.web.exposure.include=health,info,metrics,prometheus,loggers,httptrace,env,beans,resilience4j.circuitbreakers,resilience4j.ratelimiters,resilience4j.bulkheads
+# Se exponen los endpoints de Resilience4J para poder consultar el estado de
+# los CircuitBreakers, RateLimiters y Bulkheads.
+management.endpoints.web.exposure.include=health,info,metrics,prometheus,loggers,httptrace,env,beans,resilience4j.circuitbreakers,resilience4j.ratelimiters,resilience4j.bulkheads,resilience4j.threadpoolbulkheads,resilience4j.retries,resilience4j.timelimiters
+# Habilita el endpoint de Resilience4J para consultar el estado de los circuit breakers
+management.endpoint.circuitbreakers.enabled=true
+management.endpoint.ratelimiters.enabled=true
+management.endpoint.bulkheads.enabled=true
+management.endpoint.threadpoolbulkheads.enabled=true
+management.endpoint.retries.enabled=true
+management.endpoint.timelimiters.enabled=true
 
 
 management.endpoint.health.show-details=always


### PR DESCRIPTION
## Summary
- register Resilience4j actuator endpoint beans so circuit breaker state can be queried
- expose all Resilience4j actuator endpoints through `application.properties`
- document the new configuration in the README
- depend on `resilience4j-spring-boot3` for endpoint classes

## Testing
- `./mvnw -q -DskipTests package` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5747be4832496caefa05ab04461