### PR TITLE
Fix mvn verify failure in servicio-orquestador

### DIFF
--- a/servicio-orquestador/README.adoc
+++ b/servicio-orquestador/README.adoc
@@ -1,0 +1,5 @@
+= Servicio Orquestador
+
+Este módulo contiene la lógica de orquestación de las operaciones de RRHH. Forma parte del proyecto de microservicios descrito en el README principal del repositorio.
+
+Consultá `../README.adoc` para obtener información general de construcción y ejecución.


### PR DESCRIPTION
## Summary
- add a simple README.adoc to `servicio-orquestador` so the Asciidoctor plugin has a source file

## Testing
- `./mvnw -q verify` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a76f723d883249e719695bd10a83b