### PR TITLE
Fix Resilience4jEndpointConfig

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/Resilience4jEndpointConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/Resilience4jEndpointConfig.java
@@ -1,9 +1,7 @@
 package ar.org.hospitalcuencaalta.servicio_orquestador.config;
 
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
-import io.github.resilience4j.bulkhead.ThreadPoolBulkheadRegistry;
 import io.github.resilience4j.bulkhead.monitoring.endpoint.BulkheadEndpoint;
-import io.github.resilience4j.bulkhead.monitoring.endpoint.ThreadPoolBulkheadEndpoint;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.circuitbreaker.monitoring.endpoint.CircuitBreakerEndpoint;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
@@ -38,10 +36,6 @@ public class Resilience4jEndpointConfig {
         return new BulkheadEndpoint(registry);
     }
 
-    @Bean
-    public ThreadPoolBulkheadEndpoint threadPoolBulkheadEndpoint(ThreadPoolBulkheadRegistry registry) {
-        return new ThreadPoolBulkheadEndpoint(registry);
-    }
 
     @Bean
     public RetryEndpoint retryEndpoint(RetryRegistry registry) {


### PR DESCRIPTION
## Summary
- remove ThreadPoolBulkheadEndpoint bean and import as class not present

## Testing
- `mvnw -q -DskipTests -o compile` *(fails: network)*

------
https://chatgpt.com/codex/tasks/task_e_685a785025cc83249ab679cb938af6f7