### PR TITLE
Corregir la duplicación de beans del punto final de Resilience4j

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/Resilience4jEndpointConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/Resilience4jEndpointConfig.java
@@ -14,6 +14,7 @@ import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.springboot3.timelimiter.monitoring.endpoint.TimeLimiterEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 
 /**
  * Registers Resilience4j actuator endpoints when auto-configuration is not
@@ -24,33 +25,39 @@ import org.springframework.context.annotation.Configuration;
 public class Resilience4jEndpointConfig {
 
     @Bean
+    @ConditionalOnMissingBean
     public CircuitBreakerEndpoint circuitBreakerEndpoint(CircuitBreakerRegistry registry) {
         return new CircuitBreakerEndpoint(registry);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public RateLimiterEndpoint rateLimiterEndpoint(RateLimiterRegistry registry) {
         return new RateLimiterEndpoint(registry);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public BulkheadEndpoint bulkheadEndpoint(BulkheadRegistry bulkheadRegistry,
                                              ThreadPoolBulkheadRegistry threadPoolBulkheadRegistry) {
         return new BulkheadEndpoint(bulkheadRegistry, threadPoolBulkheadRegistry);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public ThreadPoolBulkheadEndpoint threadPoolBulkheadEndpoint(ThreadPoolBulkheadRegistry registry) {
         return new ThreadPoolBulkheadEndpoint(registry);
     }
 
 
     @Bean
+    @ConditionalOnMissingBean
     public RetryEndpoint retryEndpoint(RetryRegistry registry) {
         return new RetryEndpoint(registry);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public TimeLimiterEndpoint timeLimiterEndpoint(TimeLimiterRegistry registry) {
         return new TimeLimiterEndpoint(registry);
     }


### PR DESCRIPTION
## Summary
- avoid defining endpoint beans when auto-configuration already provides them

## Testing
- `mvn -pl servicio-orquestador test` *(fails: could not resolve Spring Boot parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a802ae8308324ad94f5fbb443c139