### PR TITLE
Fix Resilience4j endpoint bean conflict

### DIFF
--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -152,4 +152,4 @@ logging.level.org.apache.kafka=INFO
 # 8) Otros ajustes
 ############################################################
 #spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
-#spring.main.allow-bean-definition-overriding=true
+spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
## Summary
- enable bean overriding in servicio-orquestador

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685a83438e848324b3a521f7cc68c08b