### PR TITLE
Corregir la discrepancia entre los consumidores de empleado.deleted

### DIFF
--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/evento/EmpleadoEventPublisher.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/evento/EmpleadoEventPublisher.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EmpleadoEventPublisher {
     @Autowired
-    private KafkaTemplate<String, EmpleadoDto> kafka;
+    private KafkaTemplate<String, Object> kafka;
 
     public void publishCreated(EmpleadoDto dto) {
         kafka.send("empleado.created", dto);
@@ -18,7 +18,7 @@ public class EmpleadoEventPublisher {
         kafka.send("empleado.updated", dto);
     }
 
-    public void publishDeleted(EmpleadoDto dto) {
-        kafka.send("empleado.deleted", dto);
+    public void publishDeleted(Long id) {
+        kafka.send("empleado.deleted", id);
     }
 }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/EmpleadoService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/EmpleadoService.java
@@ -57,9 +57,8 @@ public class EmpleadoService {
     public void delete(Long id) {
         Empleado entidad = repo.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Empleado", id));
-        EmpleadoDto dto = mapper.toDto(entidad);     // mapeo previo
         repo.delete(entidad);
-        publisher.publishDeleted(dto);               // envío del DTO
+        publisher.publishDeleted(id);
     }
 
 }


### PR DESCRIPTION
## Summary
- send only employee ID on delete events
- adjust employee service accordingly

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0288b1848324b164b7af63aea30b