### PR TITLE
Solución a la saga del contrato: no se gestionan los errores de los empleados

### DIFF
--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/feign/EmpleadoClientFallback.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/feign/EmpleadoClientFallback.java
@@ -1,19 +1,19 @@
 package ar.org.hospitalcuencaalta.servicio_contrato.feign;
 
 import ar.org.hospitalcuencaalta.servicio_contrato.web.dto.EmpleadoRegistryDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class EmpleadoClientFallback implements EmpleadoClient {
 
     @Override
     public EmpleadoRegistryDto getById(Long id) {
-        // Si servicio-empleado no está disponible, devolvemos un DTO “por defecto”
-        return EmpleadoRegistryDto.builder()
-                .id(id)
-                .legajo("N/D")
-                .nombre("N/D")
-                .apellido("N/D")
-                .build();
+        // Si servicio-empleado no está disponible, propagamos excepción para
+        // que el servicio-contrato responda con error 503 y la SAGA pueda
+        // manejar el fallo correctamente.
+        log.error("[EmpleadoClientFallback] servicio-empleado no disponible al buscar id={}", id);
+        throw new RuntimeException("Servicio-empleado no disponible");
     }
 }


### PR DESCRIPTION
## Summary
- improve error handling when contract service validates employee
- adjust employee feign fallback so missing employee service produces a failure

## Testing
- `./mvnw -v` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685b0574147c83249b26fdb8920d98ee