### PR TITLE
Garantizar la limpieza del contrato tras la reversión de la saga

### DIFF
--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/controlador/ContratoController.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/controlador/ContratoController.java
@@ -32,4 +32,9 @@ public class ContratoController {
     public void delete(@PathVariable Long id) {
         svc.delete(id);
     }
+
+    @DeleteMapping("/empleado/{empleadoId}")
+    public void deleteByEmpleadoId(@PathVariable Long empleadoId) {
+        svc.deleteByEmpleadoId(empleadoId);
+    }
 }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/feign/ContratoClient.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/feign/ContratoClient.java
@@ -14,4 +14,7 @@ public interface ContratoClient {
 
     @DeleteMapping("/api/contratos/{id}")
     void delete(@PathVariable("id") Long id);
+
+    @DeleteMapping("/api/contratos/empleado/{empleadoId}")
+    void deleteByEmpleadoId(@PathVariable("empleadoId") Long empleadoId);
 }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/feign/ContratoClientFallback.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/feign/ContratoClientFallback.java
@@ -23,4 +23,9 @@ public class ContratoClientFallback implements ContratoClient {
     public void delete(Long id) {
         throw new RuntimeException("Fallback: servicio-contrato no disponible al eliminar contrato con id=" + id);
     }
+
+    @Override
+    public void deleteByEmpleadoId(Long empleadoId) {
+        throw new RuntimeException("Fallback: servicio-contrato no disponible al eliminar contratos de empleado id=" + empleadoId);
+    }
 }


### PR DESCRIPTION
## Summary
- add endpoint to delete contract by employee ID
- add fallback and Feign method to call this endpoint
- clean orphan contracts when compensating a failed saga

## Testing
- `mvn -q -pl servicio-contrato,servicio-orquestador test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b09ce67188324925f36e790ca4a09