### PR TITLE
Corrija la creación de empleados duplicados verificando el documento

### DIFF
--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/EmpleadoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/EmpleadoController.java
@@ -28,6 +28,11 @@ public class EmpleadoController {
         return svc.findById(id);
     }
 
+    @GetMapping("/documento/{documento}")
+    public EmpleadoDto getByDocumento(@PathVariable String documento) {
+        return svc.findByDocumento(documento);
+    }
+
     @PutMapping("/{id}")
     public EmpleadoDto update(@PathVariable Long id, @RequestBody EmpleadoDto dto) {
         return svc.update(id, dto);

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/EmpleadoRepository.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/EmpleadoRepository.java
@@ -2,5 +2,8 @@ package ar.org.hospitalcuencaalta.servicio_empleado.repositorio;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Empleado;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
-public interface EmpleadoRepository extends JpaRepository<Empleado, Long> {}
+public interface EmpleadoRepository extends JpaRepository<Empleado, Long> {
+    Optional<Empleado> findByDocumento(String documento);
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/EmpleadoService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/EmpleadoService.java
@@ -45,6 +45,12 @@ public class EmpleadoService {
         return mapper.toDto(entidad);
     }
 
+    public EmpleadoDto findByDocumento(String documento) {
+        Empleado entidad = repo.findByDocumento(documento)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado documento", documento));
+        return mapper.toDto(entidad);
+    }
+
     public EmpleadoDto update(Long id, EmpleadoDto dto) {
         dto.setId(id);
         Empleado entidad = mapper.toEntity(dto);

--- a/servicio-empleado/src/test/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/EmpleadoControllerWebSliceTest.java
+++ b/servicio-empleado/src/test/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/EmpleadoControllerWebSliceTest.java
@@ -71,4 +71,24 @@ class EmpleadoControllerWebSliceTest {
 
         verify(empleadoService, times(1)).delete(1L);
     }
+
+    @Test
+    void getEmpleadoByDocumento_shouldReturnDto() throws Exception {
+        EmpleadoDto dto = EmpleadoDto.builder()
+                .id(2L)
+                .nombre("Juan")
+                .apellido("Perez")
+                .documento("87654321")
+                .build();
+
+        when(empleadoService.findByDocumento("87654321")).thenReturn(dto);
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(get("/api/empleados/documento/{documento}", "87654321"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(json));
+
+        verify(empleadoService, times(1)).findByDocumento("87654321");
+    }
 }


### PR DESCRIPTION
## Summary
- implement endpoint in `EmpleadoController` to query by document
- extend `EmpleadoService` and `EmpleadoRepository` with `findByDocumento`
- add web slice test for new endpoint

## Testing
- `./mvnw -q -pl servicio-empleado test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685b0d3beae083249dcfaf4612296222