### PR TITLE
Fix consultas delete event listeners

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ContratoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ContratoEventListener.java
@@ -25,7 +25,15 @@ public class ContratoEventListener {
     }
 
     @KafkaListener(topics = "servicioContrato.contrato.deleted")
-    public void onDeleted(Long id) {
-        repo.deleteById(id);
+    public void onDeleted(Object payload) {
+        Long id = null;
+        if (payload instanceof Long l) {
+            id = l;
+        } else if (payload instanceof ContratoLaboralDto dto) {
+            id = dto.getId();
+        }
+        if (id != null) {
+            repo.deleteById(id);
+        }
     }
 }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
@@ -24,7 +24,15 @@ public class EmpleadoEventListener {
     }
 
     @KafkaListener(topics = "empleado.deleted")
-    public void onDeleted(Long id) {
-        repo.deleteById(id);
+    public void onDeleted(Object payload) {
+        Long id = null;
+        if (payload instanceof Long l) {
+            id = l;
+        } else if (payload instanceof EmpleadoDto dto) {
+            id = dto.getId();
+        }
+        if (id != null) {
+            repo.deleteById(id);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle DTO or ID payloads in `EmpleadoEventListener`
- handle DTO or ID payloads in `ContratoEventListener`

## Testing
- `mvn -q -pl servicio-consultas test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b473b77d08324883b868f7cb3067a