### PR TITLE
Handle empleado service unavailability

### DIFF
--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -102,11 +102,17 @@ resilience4j.timelimiter.configs.default.timeoutDuration=5s
 resilience4j.timelimiter.instances.servicio-empleado.baseConfig=default
 resilience4j.timelimiter.instances.servicio-contrato.baseConfig=default
 
-# 5.9) TimeLimiter para pasos de la SAGA
+# 5.9) Retry para microservicios externos
+resilience4j.retry.instances.empleadoRetry.maxAttempts=3
+resilience4j.retry.instances.empleadoRetry.waitDuration=2s
+resilience4j.retry.instances.contratoRetry.maxAttempts=3
+resilience4j.retry.instances.contratoRetry.waitDuration=2s
+
+# 5.10) TimeLimiter para pasos de la SAGA
 resilience4j.timelimiter.instances.crearEmpleadoCB.baseConfig=default
 resilience4j.timelimiter.instances.crearContratoCB.baseConfig=default
 
-# 5.10) Bulkhead – configuración base "default"
+# 5.11) Bulkhead – configuración base "default"
 resilience4j.bulkhead.configs.default.maxConcurrentCalls=20
 resilience4j.bulkhead.configs.default.maxWaitDuration=1s
 


### PR DESCRIPTION
## Summary
- add Resilience4j retry configuration for empleado client
- retry empleado Saga actions and expose constant
- return 503 with JSON when saga fails
- retry contrato Saga actions when contrato service fails

## Testing
- `./mvnw -q -pl servicio-orquestador test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685bada4f440832482f8870bc5a90afb