### PR TITLE
Corregir las pruebas del orquestador después de reintentar cambios

### DIFF
--- a/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerIntegrationTest.java
+++ b/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerIntegrationTest.java
@@ -91,11 +91,12 @@ class SagaControllerIntegrationTest {
         //    de espera en el controlador durante las pruebas
         doReturn(true).when(stateMachine).isComplete();
 
-        // 5) Stubear getState() → State<Estados, Eventos> cuyo getId() sea INICIO
+        // 5) Stubear getState() → State<Estados, Eventos> cuyo getId() sea
+        //    FINALIZADA para que el controlador retorne HTTP 200
         @SuppressWarnings("unchecked")
-        State<Estados, Eventos> estadoInicio = Mockito.mock(State.class);
-        Mockito.when(estadoInicio.getId()).thenReturn(Estados.INICIO);
-        doReturn(estadoInicio).when(stateMachine).getState();
+        State<Estados, Eventos> estadoFinal = Mockito.mock(State.class);
+        Mockito.when(estadoFinal.getId()).thenReturn(Estados.FINALIZADA);
+        doReturn(estadoFinal).when(stateMachine).getState();
     }
 
     @Test

--- a/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerWebSliceTest.java
+++ b/servicio-orquestador/src/test/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaControllerWebSliceTest.java
@@ -90,11 +90,12 @@ class SagaControllerWebSliceTest {
         doReturn(true).when(stateMachine).isComplete();
 
 
-        // 5) Stubear getState() → un State<Estados, Eventos> cuyo getId() sea INICIO
+        // 5) Stubear getState() → un State<Estados, Eventos> cuyo getId() sea
+        //    FINALIZADA para que el controlador retorne 200
         @SuppressWarnings("unchecked")
-        State<Estados, Eventos> estadoInicio = Mockito.mock(State.class);
-        Mockito.when(estadoInicio.getId()).thenReturn(Estados.INICIO);
-        doReturn(estadoInicio).when(stateMachine).getState();
+        State<Estados, Eventos> estadoFinal = Mockito.mock(State.class);
+        Mockito.when(estadoFinal.getId()).thenReturn(Estados.FINALIZADA);
+        doReturn(estadoFinal).when(stateMachine).getState();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update mocks in SagaController tests

## Testing
- `./mvnw -q -pl servicio-orquestador test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685bb142c8048324b91c4fd0d7e92291