### PR TITLE
Fix saga events published from orchestrator

### DIFF
--- a/servicio-orquestador/pom.xml
+++ b/servicio-orquestador/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>comunes</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>ar.org.hospitalcuencaalta</groupId>
+            <artifactId>servicio-contrato</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
         <!-- Resilience4j para tolerancia a fallos -->
         <dependency>
             <groupId>io.github.resilience4j</groupId>

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/SagaCompletionActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/SagaCompletionActions.java
@@ -3,6 +3,7 @@ package ar.org.hospitalcuencaalta.servicio_orquestador.accion;
 import ar.org.hospitalcuencaalta.servicio_orquestador.config.DomainEventPublisher;
 import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Estados;
 import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Eventos;
+import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.ContratoLaboralDto;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.stereotype.Component;
@@ -31,16 +32,34 @@ public class SagaCompletionActions {
         Object conDto = machine.getExtendedState().get("contratoDto", Object.class);
 
         if ("CREAR".equalsIgnoreCase(operacion)) {
-            if (empDto != null) publisher.publishEmployeeCreated(empDto);
-            if (conDto != null) publisher.publishContratoCreated(conDto);
+            if (conDto instanceof ContratoLaboralDto dto) {
+                publisher.publishContratoCreated(map(dto));
+            } else if (conDto != null) {
+                publisher.publishContratoCreated(conDto);
+            }
         } else if ("ACTUALIZAR".equalsIgnoreCase(operacion)) {
-            if (empDto != null) publisher.publishEmployeeUpdated(empDto);
-            if (conDto != null) publisher.publishContratoUpdated(conDto);
+            if (conDto instanceof ContratoLaboralDto dto) {
+                publisher.publishContratoUpdated(map(dto));
+            } else if (conDto != null) {
+                publisher.publishContratoUpdated(conDto);
+            }
         } else if ("ELIMINAR".equalsIgnoreCase(operacion)) {
             if (idContrato != null) publisher.publishContratoDeleted(idContrato);
             if (idEmpleado != null) publisher.publishEmployeeDeleted(idEmpleado);
         }
 
         publisher.publishSagaCompleted(sagaId);
+    }
+
+    private ar.org.hospitalcuencaalta.servicio_contrato.web.dto.ContratoLaboralDto map(ContratoLaboralDto dto) {
+        return ar.org.hospitalcuencaalta.servicio_contrato.web.dto.ContratoLaboralDto.builder()
+                .id(dto.getId())
+                .empleadoId(dto.getEmpleadoId())
+                .fechaDesde(dto.getFechaDesde())
+                .fechaHasta(dto.getFechaHasta())
+                .tipoContrato(dto.getTipoContrato())
+                .regimen(dto.getRegimen())
+                .salario(dto.getSalario())
+                .build();
     }
 }


### PR DESCRIPTION
## Summary
- map the contrato DTO before publishing saga events
- remove employee event publishing from orchestrator
- depend on `servicio-contrato` so mapping can reuse its DTO

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdc2e11a8832489fa05ce08be59b6