### PR TITLE
Solucionar el conflicto del registro de cambios de Liquibase en el orquestador

### DIFF
--- a/servicio-orquestador/pom.xml
+++ b/servicio-orquestador/pom.xml
@@ -36,11 +36,6 @@
             <artifactId>comunes</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>ar.org.hospitalcuencaalta</groupId>
-            <artifactId>servicio-contrato</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-        </dependency>
         <!-- Resilience4j para tolerancia a fallos -->
         <dependency>
             <groupId>io.github.resilience4j</groupId>


### PR DESCRIPTION
## Summary
- remove `servicio-contrato` dependency from `servicio-orquestador`

This avoids loading two `changelog-master.xml` files when starting the Orquestador service.

## Testing
- `./mvnw -q -pl servicio-orquestador -am test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685be1d0d5408324aef8821ba050ab31