### PR TITLE
Add CRUD and paging endpoints for employee relations

### DIFF
--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DepartamentoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DepartamentoController.java
@@ -1,0 +1,56 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.controlador;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.servicio.DepartamentoService;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDetalleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+
+@RestController
+@RequestMapping("/api/empleados/{empleadoId}/departamentos")
+@RequiredArgsConstructor
+public class DepartamentoController {
+
+    private final DepartamentoService svc;
+
+    @PostMapping
+    public DepartamentoDto create(@PathVariable Long empleadoId,
+                                  @RequestBody DepartamentoDto dto) {
+        return svc.create(empleadoId, dto);
+    }
+
+    @PutMapping("/{id}")
+    public DepartamentoDto update(@PathVariable Long empleadoId,
+                                  @PathVariable Long id,
+                                  @RequestBody DepartamentoDto dto) {
+        return svc.update(empleadoId, id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long empleadoId,
+                       @PathVariable Long id) {
+        svc.delete(empleadoId, id);
+    }
+
+    @GetMapping("/{id}")
+    public DepartamentoDetalleDto get(@PathVariable Long empleadoId,
+                                      @PathVariable Long id) {
+        return svc.get(empleadoId, id);
+    }
+
+    @GetMapping("/detalle")
+    public Page<DepartamentoDetalleDto> allDetailed(@PathVariable Long empleadoId,
+                                                    @RequestParam(defaultValue = "0") Integer page,
+                                                    @RequestParam(defaultValue = "10") Integer size) {
+        return svc.allDetailed(empleadoId, page, size);
+    }
+
+    @GetMapping
+    public Page<DepartamentoDto> all(@PathVariable Long empleadoId,
+                                     @RequestParam(defaultValue = "0") Integer page,
+                                     @RequestParam(defaultValue = "10") Integer size) {
+        return svc.all(empleadoId, page, size);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DocumentacionController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DocumentacionController.java
@@ -1,0 +1,56 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.controlador;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.servicio.DocumentacionService;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDetalleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+
+@RestController
+@RequestMapping("/api/empleados/{empleadoId}/documentaciones")
+@RequiredArgsConstructor
+public class DocumentacionController {
+
+    private final DocumentacionService svc;
+
+    @PostMapping
+    public DocumentacionDto create(@PathVariable Long empleadoId,
+                                   @RequestBody DocumentacionDto dto) {
+        return svc.create(empleadoId, dto);
+    }
+
+    @PutMapping("/{id}")
+    public DocumentacionDto update(@PathVariable Long empleadoId,
+                                   @PathVariable Long id,
+                                   @RequestBody DocumentacionDto dto) {
+        return svc.update(empleadoId, id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long empleadoId,
+                       @PathVariable Long id) {
+        svc.delete(empleadoId, id);
+    }
+
+    @GetMapping("/{id}")
+    public DocumentacionDetalleDto get(@PathVariable Long empleadoId,
+                                       @PathVariable Long id) {
+        return svc.get(empleadoId, id);
+    }
+
+    @GetMapping("/detalle")
+    public Page<DocumentacionDetalleDto> allDetailed(@PathVariable Long empleadoId,
+                                                     @RequestParam(defaultValue = "0") Integer page,
+                                                     @RequestParam(defaultValue = "10") Integer size) {
+        return svc.allDetailed(empleadoId, page, size);
+    }
+
+    @GetMapping
+    public Page<DocumentacionDto> all(@PathVariable Long empleadoId,
+                                      @RequestParam(defaultValue = "0") Integer page,
+                                      @RequestParam(defaultValue = "10") Integer size) {
+        return svc.all(empleadoId, page, size);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/PuestoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/PuestoController.java
@@ -1,0 +1,56 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.controlador;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.servicio.PuestoService;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDetalleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+
+@RestController
+@RequestMapping("/api/empleados/{empleadoId}/puestos")
+@RequiredArgsConstructor
+public class PuestoController {
+
+    private final PuestoService svc;
+
+    @PostMapping
+    public PuestoDto create(@PathVariable Long empleadoId,
+                            @RequestBody PuestoDto dto) {
+        return svc.create(empleadoId, dto);
+    }
+
+    @PutMapping("/{id}")
+    public PuestoDto update(@PathVariable Long empleadoId,
+                            @PathVariable Long id,
+                            @RequestBody PuestoDto dto) {
+        return svc.update(empleadoId, id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long empleadoId,
+                       @PathVariable Long id) {
+        svc.delete(empleadoId, id);
+    }
+
+    @GetMapping("/{id}")
+    public PuestoDetalleDto get(@PathVariable Long empleadoId,
+                                @PathVariable Long id) {
+        return svc.get(empleadoId, id);
+    }
+
+    @GetMapping("/detalle")
+    public Page<PuestoDetalleDto> allDetailed(@PathVariable Long empleadoId,
+                                              @RequestParam(defaultValue = "0") Integer page,
+                                              @RequestParam(defaultValue = "10") Integer size) {
+        return svc.allDetailed(empleadoId, page, size);
+    }
+
+    @GetMapping
+    public Page<PuestoDto> all(@PathVariable Long empleadoId,
+                               @RequestParam(defaultValue = "0") Integer page,
+                               @RequestParam(defaultValue = "10") Integer size) {
+        return svc.all(empleadoId, page, size);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/SindicatoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/SindicatoController.java
@@ -1,0 +1,56 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.controlador;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.servicio.SindicatoService;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDetalleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+
+@RestController
+@RequestMapping("/api/empleados/{empleadoId}/sindicatos")
+@RequiredArgsConstructor
+public class SindicatoController {
+
+    private final SindicatoService svc;
+
+    @PostMapping
+    public SindicatoDto create(@PathVariable Long empleadoId,
+                               @RequestBody SindicatoDto dto) {
+        return svc.create(empleadoId, dto);
+    }
+
+    @PutMapping("/{id}")
+    public SindicatoDto update(@PathVariable Long empleadoId,
+                               @PathVariable Long id,
+                               @RequestBody SindicatoDto dto) {
+        return svc.update(empleadoId, id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long empleadoId,
+                       @PathVariable Long id) {
+        svc.delete(empleadoId, id);
+    }
+
+    @GetMapping("/{id}")
+    public SindicatoDetalleDto get(@PathVariable Long empleadoId,
+                                   @PathVariable Long id) {
+        return svc.get(empleadoId, id);
+    }
+
+    @GetMapping("/detalle")
+    public Page<SindicatoDetalleDto> allDetailed(@PathVariable Long empleadoId,
+                                                 @RequestParam(defaultValue = "0") Integer page,
+                                                 @RequestParam(defaultValue = "10") Integer size) {
+        return svc.allDetailed(empleadoId, page, size);
+    }
+
+    @GetMapping
+    public Page<SindicatoDto> all(@PathVariable Long empleadoId,
+                                  @RequestParam(defaultValue = "0") Integer page,
+                                  @RequestParam(defaultValue = "10") Integer size) {
+        return svc.all(empleadoId, page, size);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/DepartamentoRepository.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/DepartamentoRepository.java
@@ -2,6 +2,15 @@ package ar.org.hospitalcuencaalta.servicio_empleado.repositorio;
 
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Departamento;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DepartamentoRepository extends JpaRepository<Departamento, Long> {}
+import java.util.Optional;
+
+public interface DepartamentoRepository extends JpaRepository<Departamento, Long> {
+
+    Page<Departamento> findByEmpleadoId(Long empleadoId, Pageable pageable);
+
+    Optional<Departamento> findByIdAndEmpleadoId(Long id, Long empleadoId);
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/DocumentacionRepository.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/DocumentacionRepository.java
@@ -1,4 +1,15 @@
 package ar.org.hospitalcuencaalta.servicio_empleado.repositorio;
 
-public interface DocumentacionRepository {
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Documentacion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DocumentacionRepository extends JpaRepository<Documentacion, Long> {
+
+    Page<Documentacion> findByEmpleadoId(Long empleadoId, Pageable pageable);
+
+    Optional<Documentacion> findByIdAndEmpleadoId(Long id, Long empleadoId);
 }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/PuestoRepository.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/PuestoRepository.java
@@ -1,6 +1,15 @@
 package ar.org.hospitalcuencaalta.servicio_empleado.repositorio;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Puesto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PuestoRepository extends JpaRepository<Puesto, Long> {}
+import java.util.Optional;
+
+public interface PuestoRepository extends JpaRepository<Puesto, Long> {
+
+    Page<Puesto> findByEmpleadoId(Long empleadoId, Pageable pageable);
+
+    Optional<Puesto> findByIdAndEmpleadoId(Long id, Long empleadoId);
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/SindicatoRepository.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/repositorio/SindicatoRepository.java
@@ -1,4 +1,15 @@
 package ar.org.hospitalcuencaalta.servicio_empleado.repositorio;
 
-public interface SindicatoRepository {
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Sindicato;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SindicatoRepository extends JpaRepository<Sindicato, Long> {
+
+    Page<Sindicato> findByEmpleadoId(Long empleadoId, Pageable pageable);
+
+    Optional<Sindicato> findByIdAndEmpleadoId(Long id, Long empleadoId);
 }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/DepartamentoService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/DepartamentoService.java
@@ -1,0 +1,72 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.servicio;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.excepcion.ResourceNotFoundException;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Departamento;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Empleado;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.DepartamentoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.EmpleadoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.DepartamentoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Service
+@RequiredArgsConstructor
+public class DepartamentoService {
+
+    private final DepartamentoRepository repo;
+    private final EmpleadoRepository empleadoRepo;
+    private final DepartamentoMapper mapper;
+
+    public DepartamentoDto create(Long empleadoId, DepartamentoDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Departamento entidad = mapper.toEntity(dto);
+        entidad.setEmpleado(empleado);
+
+        Departamento saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public DepartamentoDto update(Long empleadoId, Long id, DepartamentoDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Departamento entidad = mapper.toEntity(dto);
+        entidad.setId(id);
+        entidad.setEmpleado(empleado);
+
+        Departamento saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public void delete(Long empleadoId, Long id) {
+        Departamento entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Departamento", id));
+        repo.delete(entidad);
+    }
+
+    public DepartamentoDetalleDto get(Long empleadoId, Long id) {
+        Departamento entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Departamento", id));
+        return mapper.toDetalleDto(entidad);
+    }
+
+    public Page<DepartamentoDetalleDto> allDetailed(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDetalleDto);
+    }
+
+    public Page<DepartamentoDto> all(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDto);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/DocumentacionService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/DocumentacionService.java
@@ -1,0 +1,72 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.servicio;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.excepcion.ResourceNotFoundException;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Documentacion;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Empleado;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.DocumentacionRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.EmpleadoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.DocumentacionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentacionService {
+
+    private final DocumentacionRepository repo;
+    private final EmpleadoRepository empleadoRepo;
+    private final DocumentacionMapper mapper;
+
+    public DocumentacionDto create(Long empleadoId, DocumentacionDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Documentacion entidad = mapper.toEntity(dto);
+        entidad.setEmpleado(empleado);
+
+        Documentacion saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public DocumentacionDto update(Long empleadoId, Long id, DocumentacionDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Documentacion entidad = mapper.toEntity(dto);
+        entidad.setId(id);
+        entidad.setEmpleado(empleado);
+
+        Documentacion saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public void delete(Long empleadoId, Long id) {
+        Documentacion entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Documentacion", id));
+        repo.delete(entidad);
+    }
+
+    public DocumentacionDetalleDto get(Long empleadoId, Long id) {
+        Documentacion entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Documentacion", id));
+        return mapper.toDetalleDto(entidad);
+    }
+
+    public Page<DocumentacionDetalleDto> allDetailed(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDetalleDto);
+    }
+
+    public Page<DocumentacionDto> all(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDto);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/PuestoService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/PuestoService.java
@@ -1,0 +1,72 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.servicio;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.excepcion.ResourceNotFoundException;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Empleado;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Puesto;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.EmpleadoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.PuestoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.PuestoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Service
+@RequiredArgsConstructor
+public class PuestoService {
+
+    private final PuestoRepository repo;
+    private final EmpleadoRepository empleadoRepo;
+    private final PuestoMapper mapper;
+
+    public PuestoDto create(Long empleadoId, PuestoDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Puesto entidad = mapper.toEntity(dto);
+        entidad.setEmpleado(empleado);
+
+        Puesto saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public PuestoDto update(Long empleadoId, Long id, PuestoDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Puesto entidad = mapper.toEntity(dto);
+        entidad.setId(id);
+        entidad.setEmpleado(empleado);
+
+        Puesto saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public void delete(Long empleadoId, Long id) {
+        Puesto entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Puesto", id));
+        repo.delete(entidad);
+    }
+
+    public PuestoDetalleDto get(Long empleadoId, Long id) {
+        Puesto entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Puesto", id));
+        return mapper.toDetalleDto(entidad);
+    }
+
+    public Page<PuestoDetalleDto> allDetailed(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDetalleDto);
+    }
+
+    public Page<PuestoDto> all(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDto);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/SindicatoService.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/servicio/SindicatoService.java
@@ -1,0 +1,72 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.servicio;
+
+import ar.org.hospitalcuencaalta.servicio_empleado.excepcion.ResourceNotFoundException;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Empleado;
+import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Sindicato;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.EmpleadoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.repositorio.SindicatoRepository;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.SindicatoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Service
+@RequiredArgsConstructor
+public class SindicatoService {
+
+    private final SindicatoRepository repo;
+    private final EmpleadoRepository empleadoRepo;
+    private final SindicatoMapper mapper;
+
+    public SindicatoDto create(Long empleadoId, SindicatoDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Sindicato entidad = mapper.toEntity(dto);
+        entidad.setEmpleado(empleado);
+
+        Sindicato saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public SindicatoDto update(Long empleadoId, Long id, SindicatoDto dto) {
+        Empleado empleado = empleadoRepo.findById(empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Empleado", empleadoId));
+
+        Sindicato entidad = mapper.toEntity(dto);
+        entidad.setId(id);
+        entidad.setEmpleado(empleado);
+
+        Sindicato saved = repo.save(entidad);
+        return mapper.toDto(saved);
+    }
+
+    public void delete(Long empleadoId, Long id) {
+        Sindicato entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sindicato", id));
+        repo.delete(entidad);
+    }
+
+    public SindicatoDetalleDto get(Long empleadoId, Long id) {
+        Sindicato entidad = repo.findByIdAndEmpleadoId(id, empleadoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sindicato", id));
+        return mapper.toDetalleDto(entidad);
+    }
+
+    public Page<SindicatoDetalleDto> allDetailed(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDetalleDto);
+    }
+
+    public Page<SindicatoDto> all(Long empleadoId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return repo.findByEmpleadoId(empleadoId, pageable)
+                .map(mapper::toDto);
+    }
+}
+

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/DepartamentoDetalleDto.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/DepartamentoDetalleDto.java
@@ -1,0 +1,16 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DepartamentoDetalleDto {
+    private Long id;
+    private String nombre;
+    private EmpleadoDto empleado;
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/DocumentacionDetalleDto.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/DocumentacionDetalleDto.java
@@ -1,0 +1,17 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DocumentacionDetalleDto {
+    private Long id;
+    private String tipoDocumento;
+    private String rutaArchivo;
+    private EmpleadoDto empleado;
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/PuestoDetalleDto.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/PuestoDetalleDto.java
@@ -1,0 +1,18 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PuestoDetalleDto {
+    private Long id;
+    private String titulo;
+    private String nivelJerarquico;
+    private String descripcionFunciones;
+    private EmpleadoDto empleado;
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/SindicatoDetalleDto.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/dto/SindicatoDetalleDto.java
@@ -1,0 +1,17 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SindicatoDetalleDto {
+    private Long id;
+    private String nombre;
+    private String convenioColectivo;
+    private EmpleadoDto empleado;
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/DepartamentoMapper.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/DepartamentoMapper.java
@@ -2,11 +2,17 @@ package ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Departamento;
 import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.EmpleadoMapper;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+        uses = EmpleadoMapper.class)
 public interface DepartamentoMapper {
     DepartamentoDto toDto(Departamento e);
+
+    DepartamentoDetalleDto toDetalleDto(Departamento e);
 
     Departamento toEntity(DepartamentoDto d);
 }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/DocumentacionMapper.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/DocumentacionMapper.java
@@ -2,11 +2,17 @@ package ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Documentacion;
 import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.EmpleadoMapper;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+        uses = EmpleadoMapper.class)
 public interface DocumentacionMapper {
     DocumentacionDto toDto(Documentacion e);
+
+    DocumentacionDetalleDto toDetalleDto(Documentacion e);
 
     Documentacion toEntity(DocumentacionDto d);
 }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/PuestoMapper.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/PuestoMapper.java
@@ -2,11 +2,17 @@ package ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Puesto;
 import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.EmpleadoMapper;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+        uses = EmpleadoMapper.class)
 public interface PuestoMapper {
     PuestoDto toDto(Puesto e);
+
+    PuestoDetalleDto toDetalleDto(Puesto e);
 
     Puesto toEntity(PuestoDto d);
 }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/SindicatoMapper.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/web/mapeo/SindicatoMapper.java
@@ -2,11 +2,17 @@ package ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.modelo.Sindicato;
 import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDetalleDto;
+import ar.org.hospitalcuencaalta.servicio_empleado.web.mapeo.EmpleadoMapper;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+        uses = EmpleadoMapper.class)
 public interface SindicatoMapper {
     SindicatoDto toDto(Sindicato e);
+
+    SindicatoDetalleDto toDetalleDto(Sindicato e);
 
     Sindicato toEntity(SindicatoDto d);
 }


### PR DESCRIPTION
## Summary
- create detailed DTOs to include employee info
- enhance mappers and repositories to support fetching by employee
- add CRUD operations and pagination to services
- expose new endpoints in controllers for update, delete and paged queries

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd55abe08324a4b744b3d3d99eca