### PR TITLE
Corregir la columna empleado_id faltante en el esquema de nomina

### DIFF
--- a/servicio-nomina/src/main/resources/db/changelog/002-create-liquidaciones-conceptos.xml
+++ b/servicio-nomina/src/main/resources/db/changelog/002-create-liquidaciones-conceptos.xml
@@ -28,11 +28,12 @@
             <column name="monto" type="DECIMAL(15,2)"/>
             <column name="tipo_calculo" type="VARCHAR(20)"/>
             <column name="liquidacion_id" type="BIGINT"/>
+            <column name="empleado_id" type="BIGINT"/>
         </createTable>
         <addForeignKeyConstraint baseTableName="conceptos_liquidacion" baseColumnNames="liquidacion_id"
                                  referencedTableName="liquidaciones" referencedColumnNames="id"
                                  constraintName="fk_concepto_liquidacion"/>
-        <addForeignKeyConstraint baseTableName="conceptos_liquidacion" baseColumnNames="id"
+        <addForeignKeyConstraint baseTableName="conceptos_liquidacion" baseColumnNames="empleado_id"
                                  referencedTableName="empleado_registry" referencedColumnNames="id"
                                  constraintName="fk_concepto_empleado"/>
     </changeSet>


### PR DESCRIPTION
## Summary
- add `empleado_id` column in `conceptos_liquidacion`
- fix foreign key to reference `empleado_id`

## Testing
- `../mvnw -q -o test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685c6e7dbdcc83248de4731029b5b16b