### PR TITLE
Actualizar los documentos de la puerta de enlace y las colecciones de Postman

### DIFF
--- a/API-gateway/README.adoc
+++ b/API-gateway/README.adoc
@@ -3,3 +3,5 @@
 Encamina las peticiones entrantes hacia los diferentes microservicios de RRHH.
 
 Forma parte del proyecto de microservicios. Consultá `../README.adoc` para detalles generales.
+
+Este servicio actua como balanceador de carga utilizando Spring Cloud Gateway y Eureka. Todas las peticiones deben pasar por el gateway que enruta las escrituras al orquestador a traves de la SAGA y deriva las consultas al servicio de consultas.

--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,7 @@ Los módulos disponibles son (cada uno incluye su propio `README.adoc`):
 * link:servicio-consultas/README.adoc[servicio-consultas]
 * link:API-gateway/README.adoc[API-gateway]
 * link:servidor-para-descubrimiento/README.adoc[servidor-para-descubrimiento]
+El API Gateway se ejecuta por defecto en el puerto 8080 y distribuye las peticiones hacia los microservicios registrados en Eureka, permitiendo escalar cada servicio con múltiples instancias.
 
 == Propiedades del proyecto
 
@@ -78,13 +79,14 @@ Asegurate de que tu instancia local de MariaDB esté corriendo con esas bases de
 == Postman Tests
 
 En `docs/postman` se incluyen colecciones de Postman de ejemplo. Importá `rrhh-saga-tests.postman_collection.json` en Postman para probar los flujos de creación, actualización, eliminación y estado de la SAGA mediante los endpoints `/api/saga/empleado-contrato`. El archivo `consultas-saga-tests.postman_collection.json` contiene solicitudes adicionales que validan cómo `servicio-consultas` se actualiza luego de cada operación POST, PUT y DELETE. La respuesta del POST inicial guarda los identificadores de empleado y contrato generados en las variables de colección `{{empleadoId}}` y `{{contratoId}}` para que los siguientes pedidos las reutilicen automáticamente. También se provee `crud-tests.postman_collection.json` con ejemplos básicos para ejercitar las operaciones CRUD de todas las entidades de los microservicios.
+Todas las colecciones asumen que el punto de entrada es el API Gateway disponible en http://localhost:8080.
 
 Para eliminaciones, pasá tanto el id de empleado como el `contratoId` como parámetro de consulta, por ejemplo `DELETE /api/saga/empleado-contrato/5?contratoId=10`.
 Usá `GET /api/saga/empleado-contrato/{sagaId}` para inspeccionar el estado de una saga.
 
-Para verificar si se abre el circuit breaker de creación de empleado, hacé varios pedidos fallidos (por ejemplo deteniendo `servicio-empleado`) y luego enviá un `GET` a `http://localhost:8095/actuator/cb-state/crearEmpleadoCB?includeState=true`.
+Para verificar si se abre el circuit breaker de creación de empleado, hacé varios pedidos fallidos (por ejemplo deteniendo `servicio-empleado`) y luego enviá un `GET` a `http://localhost:8080/actuator/cb-state/crearEmpleadoCB?includeState=true`.
 El controlador `CircuitBreakerStatusController` expone de forma explícita el estado de cada breaker en esa URL `/actuator/cb-state/{name}`.
 
 La solicitud `Estado Circuit Breaker crearEmpleadoCB` de la colección de Postman espera que el estado del breaker sea `OPEN`.
 
-Para auditar los intentos de creación de empleado, consultá `GET http://localhost:8095/actuator/cb-state/empleado-actions`.
+Para auditar los intentos de creación de empleado, consultá `GET http://localhost:8080/actuator/cb-state/empleado-actions`.

--- a/docs/postman/consultas-saga-tests.postman_collection.json
+++ b/docs/postman/consultas-saga-tests.postman_collection.json
@@ -15,10 +15,10 @@
           }
         ],
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","saga","empleado-contrato"]
         },
         "body": {
@@ -48,10 +48,10 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","empleados","{{empleadoId}}"]
         }
       },
@@ -74,10 +74,10 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/api/contratos/{{contratoId}}",
+          "raw": "http://localhost:8080/api/contratos/{{contratoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","contratos","{{contratoId}}"]
         }
       },
@@ -106,10 +106,10 @@
           }
         ],
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato/{{empleadoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","saga","empleado-contrato","{{empleadoId}}"]
         },
         "body": {
@@ -136,10 +136,10 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","empleados","{{empleadoId}}"]
         }
       },
@@ -163,10 +163,10 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}?contratoId={{contratoId}}",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato/{{empleadoId}}?contratoId={{contratoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","saga","empleado-contrato","{{empleadoId}}"],
           "query": [
             {
@@ -195,10 +195,10 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/api/empleados/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","empleados","{{empleadoId}}"]
         }
       },
@@ -221,10 +221,10 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/api/contratos/{{contratoId}}",
+          "raw": "http://localhost:8080/api/contratos/{{contratoId}}",
           "protocol": "http",
           "host": ["localhost"],
-          "port": "8095",
+          "port": "8080",
           "path": ["api","contratos","{{contratoId}}"]
         }
       },

--- a/docs/postman/crud-tests.postman_collection.json
+++ b/docs/postman/crud-tests.postman_collection.json
@@ -9,12 +9,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8081/api/empleados",
+          "raw": "http://localhost:8080/api/empleados",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados"
@@ -52,12 +52,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados",
+          "raw": "http://localhost:8080/api/empleados",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados"
@@ -83,12 +83,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -115,12 +115,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -157,12 +157,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -189,12 +189,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/puestos",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/puestos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -234,12 +234,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/puestos",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/puestos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -267,12 +267,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/puestos/{{puestoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/puestos/{{puestoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -301,12 +301,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/puestos/{{puestoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/puestos/{{puestoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -345,12 +345,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/puestos/{{puestoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/puestos/{{puestoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -379,12 +379,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/documentaciones",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/documentaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -424,12 +424,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/documentaciones",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/documentaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -457,12 +457,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/documentaciones/{{documentacionId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/documentaciones/{{documentacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -491,12 +491,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/documentaciones/{{documentacionId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/documentaciones/{{documentacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -535,12 +535,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/documentaciones/{{documentacionId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/documentaciones/{{documentacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -569,12 +569,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/departamentos",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/departamentos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -614,12 +614,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/departamentos",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/departamentos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -647,12 +647,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/departamentos/{{departamentoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/departamentos/{{departamentoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -681,12 +681,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/departamentos/{{departamentoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/departamentos/{{departamentoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -725,12 +725,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/departamentos/{{departamentoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/departamentos/{{departamentoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -759,12 +759,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/sindicatos",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/sindicatos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -804,12 +804,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/sindicatos",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/sindicatos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -837,12 +837,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/sindicatos/{{sindicatoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/sindicatos/{{sindicatoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -871,12 +871,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/sindicatos/{{sindicatoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/sindicatos/{{sindicatoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -915,12 +915,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8081/api/empleados/{{empleadoId}}/sindicatos/{{sindicatoId}}",
+          "raw": "http://localhost:8080/api/empleados/{{empleadoId}}/sindicatos/{{sindicatoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8081",
+          "port": "8080",
           "path": [
             "api",
             "empleados",
@@ -949,12 +949,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8082/api/contratos",
+          "raw": "http://localhost:8080/api/contratos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8082",
+          "port": "8080",
           "path": [
             "api",
             "contratos"
@@ -992,12 +992,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8082/api/contratos",
+          "raw": "http://localhost:8080/api/contratos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8082",
+          "port": "8080",
           "path": [
             "api",
             "contratos"
@@ -1023,12 +1023,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8082/api/contratos/{{contratoId}}",
+          "raw": "http://localhost:8080/api/contratos/{{contratoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8082",
+          "port": "8080",
           "path": [
             "api",
             "contratos",
@@ -1065,12 +1065,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8082/api/contratos/{{contratoId}}",
+          "raw": "http://localhost:8080/api/contratos/{{contratoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8082",
+          "port": "8080",
           "path": [
             "api",
             "contratos",
@@ -1097,12 +1097,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8083/api/capacitaciones",
+          "raw": "http://localhost:8080/api/capacitaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "capacitaciones"
@@ -1140,12 +1140,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8083/api/capacitaciones",
+          "raw": "http://localhost:8080/api/capacitaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "capacitaciones"
@@ -1171,12 +1171,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8083/api/capacitaciones/{{capacitacionId}}",
+          "raw": "http://localhost:8080/api/capacitaciones/{{capacitacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "capacitaciones",
@@ -1203,12 +1203,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8083/api/capacitaciones/{{capacitacionId}}",
+          "raw": "http://localhost:8080/api/capacitaciones/{{capacitacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "capacitaciones",
@@ -1245,12 +1245,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8083/api/capacitaciones/{{capacitacionId}}",
+          "raw": "http://localhost:8080/api/capacitaciones/{{capacitacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "capacitaciones",
@@ -1277,12 +1277,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8083/api/evaluaciones",
+          "raw": "http://localhost:8080/api/evaluaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "evaluaciones"
@@ -1320,12 +1320,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8083/api/evaluaciones",
+          "raw": "http://localhost:8080/api/evaluaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "evaluaciones"
@@ -1351,12 +1351,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8083/api/evaluaciones/{{evaluacionId}}",
+          "raw": "http://localhost:8080/api/evaluaciones/{{evaluacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "evaluaciones",
@@ -1383,12 +1383,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8083/api/evaluaciones/{{evaluacionId}}",
+          "raw": "http://localhost:8080/api/evaluaciones/{{evaluacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "evaluaciones",
@@ -1425,12 +1425,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8083/api/evaluaciones/{{evaluacionId}}",
+          "raw": "http://localhost:8080/api/evaluaciones/{{evaluacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8083",
+          "port": "8080",
           "path": [
             "api",
             "evaluaciones",
@@ -1457,12 +1457,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8084/api/liquidaciones",
+          "raw": "http://localhost:8080/api/liquidaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "liquidaciones"
@@ -1500,12 +1500,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8084/api/liquidaciones",
+          "raw": "http://localhost:8080/api/liquidaciones",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "liquidaciones"
@@ -1531,12 +1531,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8084/api/liquidaciones/{{liquidacionId}}",
+          "raw": "http://localhost:8080/api/liquidaciones/{{liquidacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "liquidaciones",
@@ -1563,12 +1563,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8084/api/liquidaciones/{{liquidacionId}}",
+          "raw": "http://localhost:8080/api/liquidaciones/{{liquidacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "liquidaciones",
@@ -1605,12 +1605,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8084/api/liquidaciones/{{liquidacionId}}",
+          "raw": "http://localhost:8080/api/liquidaciones/{{liquidacionId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "liquidaciones",
@@ -1637,12 +1637,12 @@
       "request": {
         "method": "POST",
         "url": {
-          "raw": "http://localhost:8084/api/conceptos",
+          "raw": "http://localhost:8080/api/conceptos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "conceptos"
@@ -1680,12 +1680,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8084/api/conceptos",
+          "raw": "http://localhost:8080/api/conceptos",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "conceptos"
@@ -1711,12 +1711,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8084/api/conceptos/{{conceptoId}}",
+          "raw": "http://localhost:8080/api/conceptos/{{conceptoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "conceptos",
@@ -1743,12 +1743,12 @@
       "request": {
         "method": "PUT",
         "url": {
-          "raw": "http://localhost:8084/api/conceptos/{{conceptoId}}",
+          "raw": "http://localhost:8080/api/conceptos/{{conceptoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "conceptos",
@@ -1785,12 +1785,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8084/api/conceptos/{{conceptoId}}",
+          "raw": "http://localhost:8080/api/conceptos/{{conceptoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8084",
+          "port": "8080",
           "path": [
             "api",
             "conceptos",

--- a/docs/postman/rrhh-saga-tests.postman_collection.json
+++ b/docs/postman/rrhh-saga-tests.postman_collection.json
@@ -15,12 +15,12 @@
           }
         ],
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8095",
+          "port": "8080",
           "path": [
             "api",
             "saga",
@@ -69,12 +69,12 @@
           }
         ],
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato/{{empleadoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8095",
+          "port": "8080",
           "path": [
             "api",
             "saga",
@@ -114,12 +114,12 @@
       "request": {
         "method": "DELETE",
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{empleadoId}}?contratoId={{contratoId}}",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato/{{empleadoId}}?contratoId={{contratoId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8095",
+          "port": "8080",
           "path": [
             "api",
             "saga",
@@ -161,12 +161,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/api/saga/empleado-contrato/{{sagaId}}",
+          "raw": "http://localhost:8080/api/saga/empleado-contrato/{{sagaId}}",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8095",
+          "port": "8080",
           "path": [
             "api",
             "saga",
@@ -194,12 +194,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/actuator/cb-state/crearEmpleadoCB?includeState=true",
+          "raw": "http://localhost:8080/actuator/cb-state/crearEmpleadoCB?includeState=true",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8095",
+          "port": "8080",
           "path": [
             "actuator",
             "cb-state",
@@ -233,12 +233,12 @@
       "request": {
         "method": "GET",
         "url": {
-          "raw": "http://localhost:8095/actuator/cb-state/empleado-actions",
+          "raw": "http://localhost:8080/actuator/cb-state/empleado-actions",
           "protocol": "http",
           "host": [
             "localhost"
           ],
-          "port": "8095",
+          "port": "8080",
           "path": [
             "actuator",
             "cb-state",
@@ -264,7 +264,7 @@
       "name": "Listado operaciones de saga",
       "request": {
         "method": "GET",
-        "url": "http://localhost:8095/api/saga/operaciones"
+        "url": "http://localhost:8080/api/saga/operaciones"
       },
       "event": [
         {

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -38,8 +38,8 @@ logging.level.com.netflix.loadbalancer=DEBUG
 ############################################################
 #  - Estas dos claves son “custom” y las utilizarás en tus interfaces @FeignClient.
 #  - Para que IntelliJ no las marque como “Unknown property”, ver la sección B más abajo.
-empleado.service.url=http://localhost:8081
-contrato.service.url=http://localhost:8082
+empleado.service.url=lb://servicio-empleado
+contrato.service.url=lb://servicio-contrato
 
 # === CORRECCIÓN: Feign timeouts y logging (Spring Cloud OpenFeign 4.x) ===
 # Las propiedades deben ir prefijadas con "spring.cloud.openfeign.client.config":


### PR DESCRIPTION
## Summary
- document API Gateway usage and port in README
- mention gateway load balancer role in API-gateway README
- route examples in Postman collections through the gateway
- note gateway actuator URLs in docs
- configure orquestador service URLs to use lb:// scheme

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685c71d90dd88324858eae255ee8c763