### PR TITLE
Corregir advertencia de puerta de enlace

### DIFF
--- a/API-gateway/pom.xml
+++ b/API-gateway/pom.xml
@@ -22,6 +22,16 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-gateway</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-gateway-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gateway-server-webflux</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- exclude deprecated `spring-cloud-gateway-server`
- depend on `spring-cloud-gateway-server-webflux`

## Testing
- `./mvnw -q verify` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685d0b4755dc832497d0c2cfae29ea9b