### PR TITLE
Corregir la desuso de la dependencia de la puerta de enlace

### DIFF
--- a/API-gateway/pom.xml
+++ b/API-gateway/pom.xml
@@ -21,17 +21,7 @@
         <!-- Gateway reactivo + WebFlux -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-gateway</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.cloud</groupId>
-                    <artifactId>spring-cloud-gateway-server</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-gateway-server-webflux</artifactId>
+            <artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- remove deprecated `spring-cloud-starter-gateway`
- use `spring-cloud-starter-gateway-server-webflux` instead

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0ce7602483249cb05f0267fdef02