### PR TITLE
Mejorar la configuración de Kafka en el servicio de entrenamiento

### DIFF
--- a/servicio-entrenamiento/README.adoc
+++ b/servicio-entrenamiento/README.adoc
@@ -3,3 +3,9 @@
 Gestiona cursos y capacitaciones del personal.
 
 Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para información de uso.
+
+== Configuración de Kafka
+
+Este servicio utiliza Kafka para publicar y consumir eventos. Por defecto se conecta a `localhost:9092`, pero podés sobrescribir la URL del broker con la variable de entorno `KAFKA_BOOTSTRAP_SERVERS` cuando lo ejecutes dentro de un contenedor (por ejemplo `kafka:9092`).
+
+Para detectar tempranamente problemas de conexión con Kafka se habilitó la propiedad `spring.kafka.admin.fail-fast=true`.

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -23,7 +23,8 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 #feign.client.config.default.readTimeout=5000
 
 # Kafka Consumer
-spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+spring.kafka.admin.fail-fast=true
 spring.kafka.consumer.group-id=grupo-servicio-entrenamiento
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
## Summary
- allow overriding Kafka bootstrap servers via `KAFKA_BOOTSTRAP_SERVERS`
- fail fast if Kafka is unreachable
- document how to configure Kafka for this service

## Testing
- `./mvnw -pl servicio-entrenamiento test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685d167a55d48324b252380789efb9c6