### PR TITLE
Fix Kafka deserialization in entrenamiento service

### DIFF
--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/config/KafkaConfiguration.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/config/KafkaConfiguration.java
@@ -4,6 +4,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
 
 @Configuration
 @EnableKafka
@@ -12,5 +15,10 @@ public class KafkaConfiguration {
     @Bean
     public KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry() {
         return new KafkaListenerEndpointRegistry();
+    }
+
+    @Bean
+    public CommonErrorHandler kafkaErrorHandler() {
+        return new DefaultErrorHandler(new FixedBackOff(0L, 0L));
     }
 }

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -28,10 +28,11 @@ spring.kafka.admin.fail-fast=true
 spring.kafka.consumer.group-id=grupo-servicio-entrenamiento
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.consumer.properties.spring.json.trusted.packages=*
-
 spring.kafka.consumer.properties.spring.json.use.type.headers=true
+spring.kafka.consumer.properties.spring.json.value.default.type=ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EmpleadoRegistryDto
 spring.kafka.consumer.properties.spring.json.type.mapping=ar.org.hospitalcuencaalta.comunes.dto.EmpleadoEventDto:ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EmpleadoRegistryDto
 
 # Kafka Producer


### PR DESCRIPTION
## Summary
- configure ErrorHandlingDeserializer and default type in `application.properties`
- add `CommonErrorHandler` bean to Kafka config

## Testing
- `mvn -pl servicio-entrenamiento -am test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1949bb7483249736cb6fe5894a13