### PR TITLE
Corregir la sincronización de empleados y el mapeo de Kafka

### DIFF
--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/evento/EmpleadoSyncListener.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/evento/EmpleadoSyncListener.java
@@ -11,18 +11,22 @@ public class EmpleadoSyncListener {
     @Autowired
     private JdbcTemplate jdbc;
 
-    @KafkaListener(topics="empleado.created")
+    @KafkaListener(topics = "empleado.created")
     public void onCreated(EmpleadoRegistryDto dto) {
-        jdbc.update("INSERT INTO employee_registry(id,legajo,nombre,apellido) VALUES (?,?,?,?)",
+        jdbc.update(
+                "INSERT INTO empleado_registry(id, legajo, nombre, apellido) VALUES (?,?,?,?)",
                 dto.getId(), dto.getLegajo(), dto.getNombre(), dto.getApellido());
     }
-    @KafkaListener(topics="empleado.updated")
+
+    @KafkaListener(topics = "empleado.updated")
     public void onUpdated(EmpleadoRegistryDto dto) {
-        jdbc.update("UPDATE employee_registry SET legajo=?,nombre=?,apellido=? WHERE id=?",
+        jdbc.update(
+                "UPDATE empleado_registry SET legajo=?, nombre=?, apellido=? WHERE id=?",
                 dto.getLegajo(), dto.getNombre(), dto.getApellido(), dto.getId());
     }
-    @KafkaListener(topics="empleado.deleted")
+
+    @KafkaListener(topics = "empleado.deleted")
     public void onDeleted(Long id) {
-        jdbc.update("DELETE FROM employee_registry WHERE id=?", id);
+        jdbc.update("DELETE FROM empleado_registry WHERE id=?", id);
     }
 }

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -33,7 +33,8 @@ spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.sp
 spring.kafka.consumer.properties.spring.json.trusted.packages=*
 spring.kafka.consumer.properties.spring.json.use.type.headers=true
 spring.kafka.consumer.properties.spring.json.value.default.type=ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EmpleadoRegistryDto
-spring.kafka.consumer.properties.spring.json.type.mapping=ar.org.hospitalcuencaalta.comunes.dto.EmpleadoEventDto:ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EmpleadoRegistryDto
+spring.kafka.consumer.properties.spring.json.type.mapping=ar.org.hospitalcuencaalta.comunes.dto.EmpleadoEventDto:ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EmpleadoRegistryDto,\
+ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.EmpleadoDto:ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EmpleadoRegistryDto
 
 # Kafka Producer
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
## Summary
- correct table name in `EmpleadoSyncListener`
- handle events produced with `EmpleadoDto` by mapping them to `EmpleadoRegistryDto`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1e068b388324b3fd7ac8a38040b3