### PR TITLE
Corregir columnas faltantes en el registro de cambios de Liquibase

### DIFF
--- a/servicio-nomina/src/main/resources/db/changelog/002-create-liquidaciones-conceptos.xml
+++ b/servicio-nomina/src/main/resources/db/changelog/002-create-liquidaciones-conceptos.xml
@@ -27,6 +27,9 @@
             <column name="descripcion" type="VARCHAR(255)"/>
             <column name="monto" type="DECIMAL(15,2)"/>
             <column name="tipo_calculo" type="VARCHAR(20)"/>
+            <!-- Relacion con liquidaciones y empleado -->
+            <column name="liquidacion_id" type="BIGINT"/>
+            <column name="empleado_id" type="BIGINT"/>
         </createTable>
         <addForeignKeyConstraint baseTableName="conceptos_liquidacion" baseColumnNames="liquidacion_id"
                                  referencedTableName="liquidaciones" referencedColumnNames="id"


### PR DESCRIPTION
## Summary
- add `liquidacion_id` and `empleado_id` columns to `conceptos_liquidacion`

## Testing
- `./mvnw -q test` *(fails: failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_685fc31805288324aecbaf87e16c6a92