### PR TITLE
Corregir la ruta de enlace para los puntos finales de SAGA

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
@@ -20,6 +20,8 @@ public class GatewayConfig {
                         .uri("lb://servicio-nomina"))
                 .route("consulta_route", r -> r.path("/api/consultas/**")
                         .uri("lb://servicio-consultas"))
+                .route("saga_route", r -> r.path("/api/saga/**")
+                        .uri("lb://servicio-orquestador"))
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- ensure /api/saga/** paths are routed to `servicio-orquestador`

## Testing
- `./mvnw -v` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_685fd76552f08324a1e699ab00470d14