### PR TITLE
Arreglar ruta GET para liquidaciones

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -157,7 +157,7 @@ spring.cloud.gateway.server.webflux.routes[18].predicates[2]=Method=PUT
 spring.cloud.gateway.server.webflux.routes[18].predicates[3]=Method=DELETE
 
 spring.cloud.gateway.server.webflux.routes[19].id=liquidacion-read
-spring.cloud.gateway.server.webflux.routes[19].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[19].uri=lb://servicio-nomina
 spring.cloud.gateway.server.webflux.routes[19].predicates[0]=Path=/api/liquidaciones/**
 spring.cloud.gateway.server.webflux.routes[19].predicates[1]=Method=GET
 


### PR DESCRIPTION
## Summary
- direct GET /api/liquidaciones to `servicio-nomina` instead of `servicio-consultas`

## Testing
- `./mvnw test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6860671073f0832498603ca0130e559a