### PR TITLE
Mejorar la gestión de errores de LiquidacionService

### DIFF
--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/feign/EmpleadoClient.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/feign/EmpleadoClient.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
  */
 @FeignClient(
         name = "servicio-empleado",
+        url = "${empleado.service.url:lb://servicio-empleado}",
         fallback = EmpleadoClientFallback.class
 )
 public interface EmpleadoClient {

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
@@ -48,8 +48,10 @@ public class LiquidacionService {
             throw new ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND,
                     "Empleado con id=" + dto.getEmpleadoId() + " no existe");
         } catch (Exception ex) {
-            throw new ResponseStatusException(org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE,
-                    "No se pudo validar empleado");
+            throw new ResponseStatusException(
+                    org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE,
+                    "Error al validar empleado: " + ex.getMessage(),
+                    ex);
         }
 
         Liquidacion e = mapper.toEntity(dto);

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -23,6 +23,10 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 #feign.client.config.default.connectTimeout=2000
 #feign.client.config.default.readTimeout=5000
 
+# URL del microservicio empleado para Feign. Permite overridear la URL
+# en desarrollo sin Eureka. Por defecto usa discovery.
+empleado.service.url=lb://servicio-empleado
+
 # Kafka Consumer
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=grupo-servicio-nomina


### PR DESCRIPTION
## Summary
- propagate underlying error when validating employee
- allow overriding empleado service URL for Feign

## Testing
- `./mvnw -q -pl servicio-nomina -am test` *(fails: `java.lang.NullPointerException`)*

------
https://chatgpt.com/codex/tasks/task_e_6860743a8a2483248ad2bee65b73fdaa