### PR TITLE
Verificar la unicidad del período para la nómina

### DIFF
--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/repositorio/LiquidacionRepository.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/repositorio/LiquidacionRepository.java
@@ -3,4 +3,8 @@ package ar.org.hospitalcuencaalta.servicio_nomina.repositorio;
 import ar.org.hospitalcuencaalta.servicio_nomina.modelo.Liquidacion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LiquidacionRepository extends JpaRepository<Liquidacion, Long> {}
+import java.util.Optional;
+
+public interface LiquidacionRepository extends JpaRepository<Liquidacion, Long> {
+    Optional<Liquidacion> findByPeriodoAndEmpleadoId(String periodo, Long empleadoId);
+}

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
@@ -16,6 +16,7 @@ import ar.org.hospitalcuencaalta.servicio_nomina.web.mapeo.LiquidacionMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -52,6 +53,11 @@ public class LiquidacionService {
                     org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE,
                     "Error al validar empleado: " + ex.getMessage(),
                     ex);
+        }
+
+        if (repo.findByPeriodoAndEmpleadoId(dto.getPeriodo(), dto.getEmpleadoId()).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Ya existe una liquidacion para el periodo " + dto.getPeriodo());
         }
 
         Liquidacion e = mapper.toEntity(dto);

--- a/servicio-nomina/src/main/resources/db/changelog/004-unique-liquidacion-periodo.xml
+++ b/servicio-nomina/src/main/resources/db/changelog/004-unique-liquidacion-periodo.xml
@@ -1,0 +1,11 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="
+                     http://www.liquibase.org/xml/ns/dbchangelog
+                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="4" author="codex">
+        <addUniqueConstraint tableName="liquidaciones"
+                             columnNames="periodo,empleado_id"
+                             constraintName="uk_periodo_empleado"/>
+    </changeSet>
+</databaseChangeLog>

--- a/servicio-nomina/src/main/resources/db/changelog/changelog-master.xml
+++ b/servicio-nomina/src/main/resources/db/changelog/changelog-master.xml
@@ -9,4 +9,5 @@
     <include file="db/changelog/001-create-empleado-registry.xml"/>
     <include file="db/changelog/002-create-liquidaciones-conceptos.xml"/>
     <include file="/db/changelog/003-empleado-concepto.xml"/>
+    <include file="db/changelog/004-unique-liquidacion-periodo.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add unique constraint for `liquidaciones` period and employee
- prevent creating a payroll when another exists for the same employee and period

## Testing
- `./mvnw -q -pl servicio-nomina test` *(fails: java.lang.NullPointerException: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_68607ed0185483249794e3ac4ceea874