### PR TITLE
Fix uniqueness check for Liquidacion

### DIFF
--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/modelo/Liquidacion.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/modelo/Liquidacion.java
@@ -21,7 +21,7 @@ public class Liquidacion {
     private java.math.BigDecimal descuentos;
     private java.math.BigDecimal sueldoNeto;
 
-    @Column(name = "empleado_id", insertable = false, updatable = false)
+    @Column(name = "empleado_id")
     private Long empleadoId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
+++ b/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
@@ -1,0 +1,71 @@
+package ar.org.hospitalcuencaalta.servicio_nomina.servicio;
+
+import ar.org.hospitalcuencaalta.servicio_nomina.modelo.Liquidacion;
+import ar.org.hospitalcuencaalta.servicio_nomina.repositorio.LiquidacionRepository;
+import ar.org.hospitalcuencaalta.servicio_nomina.repositorio.ConceptoLiquidacionRepository;
+import ar.org.hospitalcuencaalta.servicio_nomina.repositorio.EmpleadoConceptoRepository;
+import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.LiquidacionDto;
+import ar.org.hospitalcuencaalta.servicio_nomina.web.mapeo.LiquidacionDetalleMapper;
+import ar.org.hospitalcuencaalta.servicio_nomina.web.mapeo.LiquidacionMapper;
+import ar.org.hospitalcuencaalta.servicio_nomina.feign.EmpleadoClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LiquidacionServiceTest {
+
+    @Mock
+    private LiquidacionRepository repo;
+    @Mock
+    private ConceptoLiquidacionRepository conceptoRepo;
+    @Mock
+    private EmpleadoConceptoRepository empleadoConceptoRepo;
+    @Mock
+    private EmpleadoClient empleadoClient;
+    @Mock
+    private KafkaTemplate<String, Object> kafka;
+    @Spy
+    private LiquidacionMapper mapper = Mappers.getMapper(LiquidacionMapper.class);
+    @Spy
+    private LiquidacionDetalleMapper detalleMapper = Mappers.getMapper(LiquidacionDetalleMapper.class);
+
+    @InjectMocks
+    private LiquidacionService service;
+
+    @BeforeEach
+    void setup() {
+        // detalleMapper doesn't have other dependencies
+    }
+
+    @Test
+    void create_whenDuplicatePeriodForEmployee_throwsBadRequest() {
+        LiquidacionDto dto = LiquidacionDto.builder()
+                .periodo("2024-05")
+                .empleadoId(10L)
+                .build();
+
+        when(empleadoClient.getById(10L)).thenReturn(null);
+        when(repo.findByPeriodoAndEmpleadoId("2024-05", 10L))
+                .thenReturn(Optional.of(new Liquidacion()));
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Ya existe una liquidacion");
+
+        verify(repo, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `empleadoId` column is persisted
- test `LiquidacionService` duplicate period validation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68608468afbc83248a9c7e26e8de99ad