### PR TITLE
Implementar la sincronización de empleados mediante la finalización de SAGA

### DIFF
--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/servicio/ContratoService.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/servicio/ContratoService.java
@@ -41,12 +41,16 @@ public class ContratoService {
         if (!empleadoRegistryRepo.existsById(dto.getEmpleadoId())) {
             try {
                 EmpleadoRegistryDto emp = empleadoClient.getById(dto.getEmpleadoId());
+                // Sincronizar localmente para futuros intentos
                 empleadoRegistryRepo.save(EmpleadoRegistry.builder()
                         .id(emp.getId())
                         .legajo(emp.getLegajo())
                         .nombre(emp.getNombre())
                         .apellido(emp.getApellido())
                         .build());
+                // No se pudo confirmar recepción del evento
+                throw new ResponseStatusException(SERVICE_UNAVAILABLE,
+                        "Empleado no sincronizado aun");
             } catch (FeignException.NotFound nf) {
                 throw new ResponseStatusException(NOT_FOUND,
                         "Empleado con id=" + dto.getEmpleadoId() + " no existe");

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/CapacitacionService.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/CapacitacionService.java
@@ -45,6 +45,8 @@ public class CapacitacionService {
                         .nombre(emp.getNombre())
                         .apellido(emp.getApellido())
                         .build());
+                throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                        "Empleado no sincronizado aun");
             } catch (FeignException.NotFound nf) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Empleado con id=" + dto.getEmpleadoId() + " no existe");

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/EvaluacionService.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/servicio/EvaluacionService.java
@@ -45,6 +45,8 @@ public class EvaluacionService {
                         .nombre(emp.getNombre())
                         .apellido(emp.getApellido())
                         .build());
+                throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                        "Empleado no sincronizado aun");
             } catch (FeignException.NotFound nf) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Empleado con id=" + dto.getEmpleadoId() + " no existe");
@@ -62,6 +64,8 @@ public class EvaluacionService {
                         .nombre(emp.getNombre())
                         .apellido(emp.getApellido())
                         .build());
+                throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                        "Empleado no sincronizado aun");
             } catch (FeignException.NotFound nf) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Empleado con id=" + dto.getEvaluadorId() + " no existe");

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
@@ -57,6 +57,8 @@ public class LiquidacionService {
                         .nombre(emp.getNombre())
                         .apellido(emp.getApellido())
                         .build());
+                throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                        "Empleado no sincronizado aun");
             } catch (FeignException.NotFound nf) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Empleado con id=" + dto.getEmpleadoId() + " no existe");

--- a/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
+++ b/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
@@ -94,7 +94,7 @@ class LiquidacionServiceTest {
     }
 
     @Test
-    void create_whenEmpleadoSeObtieneRemotamente_loGuardaLocalmente() {
+    void create_whenEmpleadoSeObtieneRemotamente_rechazaOperacion() {
         LiquidacionDto dto = LiquidacionDto.builder()
                 .periodo("2024-07")
                 .empleadoId(7L)
@@ -104,13 +104,12 @@ class LiquidacionServiceTest {
         EmpleadoRegistryDto empDto = EmpleadoRegistryDto.builder()
                 .id(7L).legajo("X1").nombre("Ana").apellido("Lopez").build();
         when(empleadoClient.getById(7L)).thenReturn(empDto);
-        when(repo.findByPeriodoAndEmpleadoId("2024-07", 7L)).thenReturn(Optional.empty());
-        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        LiquidacionDto result = service.create(dto);
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("sincronizado");
 
         verify(empleadoRegistryRepo).save(any());
-        verify(repo).save(any());
-        assertEquals("2024-07", result.getPeriodo());
+        verify(repo, never()).save(any());
     }
 }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/SagaCompletionActions.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/accion/SagaCompletionActions.java
@@ -4,6 +4,8 @@ import ar.org.hospitalcuencaalta.servicio_orquestador.config.DomainEventPublishe
 import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Estados;
 import ar.org.hospitalcuencaalta.servicio_orquestador.modelo.Eventos;
 import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.ContratoLaboralDto;
+import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.EmpleadoDto;
+import ar.org.hospitalcuencaalta.comunes.dto.EmpleadoEventDto;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.stereotype.Component;
@@ -30,12 +32,22 @@ public class SagaCompletionActions {
         Object conDto = machine.getExtendedState().get("contratoDto", Object.class);
 
         if ("CREAR".equalsIgnoreCase(operacion)) {
+            if (empDto instanceof EmpleadoDto dto) {
+                publisher.publishEmployeeCreated(map(dto));
+            } else if (empDto != null) {
+                publisher.publishEmployeeCreated(empDto);
+            }
             if (conDto instanceof ContratoLaboralDto dto) {
                 publisher.publishContratoCreated(map(dto));
             } else if (conDto != null) {
                 publisher.publishContratoCreated(conDto);
             }
         } else if ("ACTUALIZAR".equalsIgnoreCase(operacion)) {
+            if (empDto instanceof EmpleadoDto dto) {
+                publisher.publishEmployeeUpdated(map(dto));
+            } else if (empDto != null) {
+                publisher.publishEmployeeUpdated(empDto);
+            }
             if (conDto instanceof ContratoLaboralDto dto) {
                 publisher.publishContratoUpdated(map(dto));
             } else if (conDto != null) {
@@ -47,6 +59,15 @@ public class SagaCompletionActions {
         }
 
         publisher.publishSagaCompleted(sagaId);
+    }
+
+    private EmpleadoEventDto map(EmpleadoDto dto) {
+        return EmpleadoEventDto.builder()
+                .id(dto.getId())
+                .legajo(null)
+                .nombre(dto.getNombre())
+                .apellido(dto.getApellido())
+                .build();
     }
 
     private ContratoLaboralDto map(ContratoLaboralDto dto) {


### PR DESCRIPTION
## Summary
- publish `empleado.created` and `empleado.updated` when a SAGA finishes
- refuse local operations when employee registry isn't synchronised
- update unit tests accordingly

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861049f376483249a40797ac6d3aabd