### PR TITLE
Fix FeignException creation in LiquidacionServiceTest

### DIFF
--- a/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
+++ b/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
@@ -11,6 +11,7 @@ import ar.org.hospitalcuencaalta.servicio_nomina.repositorio.EmpleadoRegistryRep
 import ar.org.hospitalcuencaalta.servicio_nomina.feign.EmpleadoClient;
 import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.EmpleadoRegistryDto;
 import feign.FeignException;
+import feign.Request;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,7 +85,15 @@ class LiquidacionServiceTest {
                 .build();
 
         when(empleadoRegistryRepo.existsById(5L)).thenReturn(false);
-        when(empleadoClient.getById(5L)).thenThrow(new FeignException.NotFound("not found", null, null, null));
+
+        Request request = Request.create(Request.HttpMethod.GET,
+                "/api/empleados/5",
+                java.util.Collections.emptyMap(),
+                null,
+                java.nio.charset.StandardCharsets.UTF_8,
+                null);
+        when(empleadoClient.getById(5L))
+                .thenThrow(new FeignException.NotFound("not found", request, null, null));
 
         assertThatThrownBy(() -> service.create(dto))
                 .isInstanceOf(ResponseStatusException.class)


### PR DESCRIPTION
## Summary
- fix `LiquidacionServiceTest` so it creates a valid `FeignException.NotFound`

## Testing
- `./mvnw -q -pl servicio-nomina test` *(fails: Cannot invoke "String.lastIndexOf" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6861112b3dd08324a2b0988fbcef6098