### PR TITLE
Fix employee document lookup and index

### DIFF
--- a/servicio-empleado/src/main/resources/db/changelog/001-create-empleados.xml
+++ b/servicio-empleado/src/main/resources/db/changelog/001-create-empleados.xml
@@ -20,6 +20,13 @@
             <column name="fecha_ingreso"   type="DATE"/>
             <column name="fecha_egreso"    type="DATE"/>
         </createTable>
+        <!-- Índices para optimizar búsquedas -->
+        <createIndex indexName="idx_empleado_documento" tableName="empleados">
+            <column name="documento"/>
+        </createIndex>
+        <addUniqueConstraint tableName="empleados"
+                             columnNames="documento"
+                             constraintName="uc_empleado_documento"/>
     </changeSet>
 </databaseChangeLog>
 


### PR DESCRIPTION
## Summary
- enforce uniqueness of `documento` in Liquibase changelog
- validate duplicates on employee create and update

## Testing
- `./mvnw -pl servicio-empleado test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_68611ccf64f48324a11741f840a739aa