### PR TITLE
Fix training service tests

### DIFF
--- a/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/ServicioEntrenamientoApplicationTests.java
+++ b/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/ServicioEntrenamientoApplicationTests.java
@@ -3,7 +3,7 @@ package ar.org.hospitalcuencaalta.servicio_entrenamiento;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "eureka.client.enabled=false")
 class ServicioEntrenamientoApplicationTests {
 
     @Test

--- a/servicio-entrenamiento/src/test/resources/application.properties
+++ b/servicio-entrenamiento/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+eureka.client.enabled=false


### PR DESCRIPTION
## Summary
- disable Eureka client in ServicioEntrenamientoApplicationTests
- provide test application.properties to disable Eureka

## Testing
- `mvn -pl servicio-entrenamiento test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6861208b35208324920ea159897cafcf