### PR TITLE
Corregir la búsqueda del registro de cambios de Liquibase en las pruebas

### DIFF
--- a/servicio-entrenamiento/src/test/resources/application.properties
+++ b/servicio-entrenamiento/src/test/resources/application.properties
@@ -1,1 +1,3 @@
 eureka.client.enabled=false
+
+spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml


### PR DESCRIPTION
## Summary
- ensure tests use changelog-master.xml for Liquibase

## Testing
- `mvnw -pl servicio-entrenamiento test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6861233e2c2883249f670c1c69376a40