### PR TITLE
Corregir el ID del grupo de Kafka en las pruebas de ServicioEntrenamiento

### DIFF
--- a/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/ServicioEntrenamientoApplicationTests.java
+++ b/servicio-entrenamiento/src/test/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/ServicioEntrenamientoApplicationTests.java
@@ -3,7 +3,11 @@ package ar.org.hospitalcuencaalta.servicio_entrenamiento;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(properties = "eureka.client.enabled=false")
+@SpringBootTest(properties = {
+        "eureka.client.enabled=false",
+        "spring.kafka.consumer.group-id=test",
+        "spring.kafka.listener.auto-startup=false"
+})
 class ServicioEntrenamientoApplicationTests {
 
     @Test


### PR DESCRIPTION
## Summary
- ensure Kafka consumer group ID is defined for context load tests

## Testing
- `./mvnw -q -pl servicio-entrenamiento -Dtest=ServicioEntrenamientoApplicationTests test` *(fails: Cannot invoke "String.lastIndexOf(String)")*

------
https://chatgpt.com/codex/tasks/task_e_68612714dacc8324b8b33bd6260bee60