### PR TITLE
Corregir la propagación de eliminaciones en el servicio de consultas

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
@@ -2,6 +2,7 @@ package ar.org.hospitalcuencaalta.servicio_consultas.evento;
 
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.EmpleadoProjection;
 import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.EmpleadoProjectionRepository;
+import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.ContratoProjectionRepository;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.EmpleadoDto;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.EmpleadoProjectionMapper;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Component
 public class EmpleadoEventListener {
     @Autowired private EmpleadoProjectionRepository repo;
+    @Autowired private ContratoProjectionRepository contratoRepo;
     @Autowired private EmpleadoProjectionMapper mapper;
 
     @KafkaListener(topics = "empleado.created")
@@ -32,6 +34,7 @@ public class EmpleadoEventListener {
             id = dto.getId();
         }
         if (id != null) {
+            contratoRepo.deleteByEmpleado_Id(id);
             repo.deleteById(id);
         }
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/ContratoProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/ContratoProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.ContratoProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ContratoProjectionRepository extends JpaRepository<ContratoProjection,Long> {}
+public interface ContratoProjectionRepository extends JpaRepository<ContratoProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+}


### PR DESCRIPTION
## Summary
- cascade deletions in consultas service for employees
- add repository method to delete contracts by employee id

## Testing
- `./mvnw -q -pl servicio-consultas -am test` *(fails: Maven wrapper couldn't run)*

------
https://chatgpt.com/codex/tasks/task_e_6861d34e75bc8324bedc1a66a2c5a573