### PR TITLE
Corregir las eliminaciones en cascada para las proyecciones de empleados

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
@@ -1,8 +1,7 @@
 package ar.org.hospitalcuencaalta.servicio_consultas.evento;
 
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.EmpleadoProjection;
-import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.EmpleadoProjectionRepository;
-import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.ContratoProjectionRepository;
+import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.*;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.EmpleadoDto;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.EmpleadoProjectionMapper;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -13,6 +12,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class EmpleadoEventListener {
     @Autowired private EmpleadoProjectionRepository repo;
     @Autowired private ContratoProjectionRepository contratoRepo;
+    @Autowired private JornadaProjectionRepository jornadaRepo;
+    @Autowired private TurnoProjectionRepository turnoRepo;
+    @Autowired private AsistenciaProjectionRepository asistenciaRepo;
+    @Autowired private CapacitacionProjectionRepository capacitacionRepo;
+    @Autowired private LicenciaProjectionRepository licenciaRepo;
+    @Autowired private VacacionProjectionRepository vacacionRepo;
+    @Autowired private EvaluacionProjectionRepository evaluacionRepo;
+    @Autowired private ConceptoLiquidacionProjectionRepository conceptoRepo;
+    @Autowired private LiquidacionProjectionRepository liquidacionRepo;
     @Autowired private EmpleadoProjectionMapper mapper;
 
     @KafkaListener(topics = "empleado.created")
@@ -34,6 +42,17 @@ public class EmpleadoEventListener {
             id = dto.getId();
         }
         if (id != null) {
+            // Eliminar dependencias para respetar las claves foráneas
+            asistenciaRepo.deleteByEmpleado_Id(id);
+            turnoRepo.deleteByJornada_Contrato_Empleado_Id(id);
+            jornadaRepo.deleteByContrato_Empleado_Id(id);
+            capacitacionRepo.deleteByEmpleado_Id(id);
+            licenciaRepo.deleteByEmpleado_Id(id);
+            vacacionRepo.deleteByEmpleado_Id(id);
+            evaluacionRepo.deleteByEmpleado_Id(id);
+            evaluacionRepo.deleteByEvaluador_Id(id);
+            conceptoRepo.deleteByLiquidacion_Empleado_Id(id);
+            liquidacionRepo.deleteByEmpleado_Id(id);
             contratoRepo.deleteByEmpleado_Id(id);
             repo.deleteById(id);
         }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/AsistenciaProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/AsistenciaProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.AsistenciaProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AsistenciaProjectionRepository extends JpaRepository<AsistenciaProjection,Long> {}
+public interface AsistenciaProjectionRepository extends JpaRepository<AsistenciaProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/CapacitacionProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/CapacitacionProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.CapacitacionProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CapacitacionProjectionRepository extends JpaRepository<CapacitacionProjection,Long> {}
+public interface CapacitacionProjectionRepository extends JpaRepository<CapacitacionProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/ConceptoLiquidacionProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/ConceptoLiquidacionProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.ConceptoLiquidacionProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ConceptoLiquidacionProjectionRepository extends JpaRepository<ConceptoLiquidacionProjection,Long> {}
+public interface ConceptoLiquidacionProjectionRepository extends JpaRepository<ConceptoLiquidacionProjection,Long> {
+    void deleteByLiquidacion_Empleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/EvaluacionProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/EvaluacionProjectionRepository.java
@@ -3,4 +3,7 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.EvaluacionProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EvaluacionProjectionRepository extends JpaRepository<EvaluacionProjection,Long> {}
+public interface EvaluacionProjectionRepository extends JpaRepository<EvaluacionProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+    void deleteByEvaluador_Id(Long evaluadorId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/JornadaProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/JornadaProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.JornadaProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JornadaProjectionRepository extends JpaRepository<JornadaProjection,Long> {}
+public interface JornadaProjectionRepository extends JpaRepository<JornadaProjection,Long> {
+    void deleteByContrato_Empleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/LicenciaProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/LicenciaProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.LicenciaProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LicenciaProjectionRepository extends JpaRepository<LicenciaProjection,Long> {}
+public interface LicenciaProjectionRepository extends JpaRepository<LicenciaProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/LiquidacionProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/LiquidacionProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.LiquidacionProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LiquidacionProjectionRepository extends JpaRepository<LiquidacionProjection,Long> {}
+public interface LiquidacionProjectionRepository extends JpaRepository<LiquidacionProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/TurnoProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/TurnoProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.TurnoProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TurnoProjectionRepository extends JpaRepository<TurnoProjection,Long> {}
+public interface TurnoProjectionRepository extends JpaRepository<TurnoProjection,Long> {
+    void deleteByJornada_Contrato_Empleado_Id(Long empleadoId);
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/VacacionProjectionRepository.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/repositorio/VacacionProjectionRepository.java
@@ -3,4 +3,6 @@ package ar.org.hospitalcuencaalta.servicio_consultas.repositorio;
 import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.VacacionProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VacacionProjectionRepository extends JpaRepository<VacacionProjection,Long> {}
+public interface VacacionProjectionRepository extends JpaRepository<VacacionProjection,Long> {
+    void deleteByEmpleado_Id(Long empleadoId);
+}


### PR DESCRIPTION
## Summary
- add deleteByEmpleado_Id methods to projection repositories
- cascade deletion of dependent projections when receiving `empleado.deleted`

## Testing
- `./mvnw -q -pl servicio-consultas -am test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddcbbdac8324936125b43d2c4fc8