### PR TITLE
Corregir la eliminación del detector de eventos

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=file:.mvn/wrapper/apache-maven-3.9.9-bin.zip
-wrapperUrl=file:.mvn/wrapper/maven-wrapper.jar
+distributionUrl=file:./.mvn/wrapper/apache-maven-3.9.9-bin.zip
+wrapperUrl=file:./.mvn/wrapper/maven-wrapper.jar

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
@@ -4,6 +4,7 @@ import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.EmpleadoProject
 import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.*;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.EmpleadoDto;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.EmpleadoProjectionMapper;
+import java.util.Map;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,10 +37,15 @@ public class EmpleadoEventListener {
     @KafkaListener(topics = "empleado.deleted")
     public void onDeleted(Object payload) {
         Long id = null;
-        if (payload instanceof Long l) {
-            id = l;
+        if (payload instanceof Number n) {
+            id = n.longValue();
         } else if (payload instanceof EmpleadoDto dto) {
             id = dto.getId();
+        } else if (payload instanceof Map<?, ?> map) {
+            Object value = map.get("id");
+            if (value instanceof Number n) {
+                id = n.longValue();
+            }
         }
         if (id != null) {
             // Eliminar dependencias para respetar las claves foráneas


### PR DESCRIPTION
## Summary
- make mvnw paths relative so wrapper works offline
- handle numeric/Map payloads in employee deletion listener

## Testing
- `mvn -pl servicio-consultas test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862508b4c0483248e2ae858b3410f4a