### PR TITLE
Corregir la transacción del oyente de eliminación de Empleado

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoEventListener.java
@@ -7,6 +7,7 @@ import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.EmpleadoProjectio
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class EmpleadoEventListener {
@@ -34,6 +35,7 @@ public class EmpleadoEventListener {
     }
 
     @KafkaListener(topics = "empleado.deleted")
+    @Transactional
     public void onDeleted(Long id) {
         if (id != null) {
             // Eliminar dependencias para respetar las claves foráneas


### PR DESCRIPTION
## Summary
- wrap employee-deletion listener logic in a transaction

## Testing
- `mvn -q -pl servicio-consultas test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686258f46940832496c27353441ae777