### PR TITLE
Fix route for conceptos and simplify liquidación creation

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
@@ -18,6 +18,8 @@ public class GatewayConfig {
                         .uri("lb://servicio-entrenamiento"))
                 .route("nomina_route", r -> r.path("/api/liquidaciones/**", "/api/conceptos/**")
                         .uri("lb://servicio-nomina"))
+                .route("empleado_concepto_route", r -> r.path("/api/empleados/**/conceptos/**")
+                        .uri("lb://servicio-nomina"))
                 .route("consulta_route", r -> r.path("/api/consultas/**")
                         .uri("lb://servicio-consultas"))
                 .route("saga_route", r -> r.path("/api/saga/**")

--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -174,6 +174,12 @@ spring.cloud.gateway.server.webflux.routes[21].uri=lb://servicio-consultas
 spring.cloud.gateway.server.webflux.routes[21].predicates[0]=Path=/api/conceptos/**
 spring.cloud.gateway.server.webflux.routes[21].predicates[1]=Method=GET
 
+# Ruta adicional para asignar un concepto a un empleado
+spring.cloud.gateway.server.webflux.routes[24].id=empleado-concepto-write
+spring.cloud.gateway.server.webflux.routes[24].uri=lb://servicio-nomina
+spring.cloud.gateway.server.webflux.routes[24].predicates[0]=Path=/api/empleados/**/conceptos/**
+spring.cloud.gateway.server.webflux.routes[24].predicates[1]=Method=POST
+
 # ========================================
 # Rutas de SAGA (todas en el path /api/saga/)
 # ========================================

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
@@ -73,14 +73,14 @@ public class LiquidacionService {
         }
 
         if (!empleadoRegistryRepo.existsByIdAndDocumento(emp.getId(), emp.getDocumento())) {
+            // Sincronizamos la información del empleado localmente para futuras operaciones,
+            // pero permitimos continuar sin rechazar la creación de la liquidación.
             empleadoRegistryRepo.save(EmpleadoRegistry.builder()
                     .id(emp.getId())
                     .documento(emp.getDocumento())
                     .nombre(emp.getNombre())
                     .apellido(emp.getApellido())
                     .build());
-            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-                    "Empleado no sincronizado aun");
         }
 
         Liquidacion e = mapper.toEntity(dto);

--- a/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
+++ b/servicio-nomina/src/test/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionServiceTest.java
@@ -100,7 +100,7 @@ class LiquidacionServiceTest {
     }
 
     @Test
-    void create_whenEmpleadoSeObtieneRemotamente_rechazaOperacion() {
+    void create_whenEmpleadoSeObtieneRemotamente_guardaLiquidacion() {
         LiquidacionDto dto = LiquidacionDto.builder()
                 .periodo("2024-07")
                 .empleadoId(7L)
@@ -110,12 +110,15 @@ class LiquidacionServiceTest {
                 .id(7L).documento("XD").nombre("Ana").apellido("Lopez").build();
         when(empleadoClient.getById(7L)).thenReturn(empDto);
         when(empleadoRegistryRepo.existsByIdAndDocumento(7L, "XD")).thenReturn(false);
+        when(repo.findByPeriodoAndEmpleadoId("2024-07", 7L)).thenReturn(Optional.empty());
+        Liquidacion saved = new Liquidacion();
+        saved.setId(99L);
+        when(repo.save(any())).thenReturn(saved);
 
-        assertThatThrownBy(() -> service.create(dto))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("sincronizado");
+        LiquidacionDto result = service.create(dto);
 
         verify(empleadoRegistryRepo).save(any());
-        verify(repo, never()).save(any());
+        verify(repo).save(any());
+        assertEquals(99L, result.getId());
     }
 }


### PR DESCRIPTION
## Summary
- route `/api/empleados/**/conceptos/**` to servicio-nomina in gateway
- map same POST route in gateway properties
- allow LiquidacionService to create payroll even if the employee registry is not yet synced
- update unit test accordingly

## Testing
- `./mvnw -q test` *(fails: NullPointerException in Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686328f031888324a79f97a4e2529f6f