### PR TITLE
Corregir el patrón de ruta de la puerta de enlace

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
@@ -18,7 +18,7 @@ public class GatewayConfig {
                         .uri("lb://servicio-entrenamiento"))
                 .route("nomina_route", r -> r.path("/api/liquidaciones/**", "/api/conceptos/**")
                         .uri("lb://servicio-nomina"))
-                .route("empleado_concepto_route", r -> r.path("/api/empleados/**/conceptos/**")
+                .route("empleado_concepto_route", r -> r.path("/api/empleados/{id}/conceptos/**")
                         .uri("lb://servicio-nomina"))
                 .route("consulta_route", r -> r.path("/api/consultas/**")
                         .uri("lb://servicio-consultas"))


### PR DESCRIPTION
## Summary
- update GatewayConfig route pattern for conceptos by employee

## Testing
- `./mvnw -q -pl API-gateway -am test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_68632b958490832495a6e0b4cf856792