### PR TITLE
Fix path pattern in API Gateway configuration

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -177,7 +177,7 @@ spring.cloud.gateway.server.webflux.routes[21].predicates[1]=Method=GET
 # Ruta adicional para asignar un concepto a un empleado
 spring.cloud.gateway.server.webflux.routes[24].id=empleado-concepto-write
 spring.cloud.gateway.server.webflux.routes[24].uri=lb://servicio-nomina
-spring.cloud.gateway.server.webflux.routes[24].predicates[0]=Path=/api/empleados/**/conceptos/**
+spring.cloud.gateway.server.webflux.routes[24].predicates[0]=Path=/api/empleados/{id}/conceptos/**
 spring.cloud.gateway.server.webflux.routes[24].predicates[1]=Method=POST
 
 # ========================================


### PR DESCRIPTION
## Summary
- correct wildcard pattern for empleado-concepto route in API Gateway

## Testing
- `mvn -q -pl API-gateway test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6863371aa65883249114773253fb3ac2