### PR TITLE
Corregir la propagación de eventos de nómina

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoConceptoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoConceptoEventListener.java
@@ -1,0 +1,19 @@
+package ar.org.hospitalcuencaalta.servicio_consultas.evento;
+
+import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.EmpleadoConceptoProjectionRepository;
+import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.EmpleadoConceptoDto;
+import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.EmpleadoConceptoProjectionMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmpleadoConceptoEventListener {
+    @Autowired private EmpleadoConceptoProjectionRepository repo;
+    @Autowired private EmpleadoConceptoProjectionMapper mapper;
+
+    @KafkaListener(topics = "servicioNomina.empleadoConcepto.created")
+    public void onCreated(EmpleadoConceptoDto dto) {
+        repo.save(mapper.toEmpleadoConcepto(dto));
+    }
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/web/dto/EmpleadoConceptoDto.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/web/dto/EmpleadoConceptoDto.java
@@ -1,0 +1,16 @@
+package ar.org.hospitalcuencaalta.servicio_consultas.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmpleadoConceptoDto {
+    private Long id;
+    private Long empleadoId;
+    private Long conceptoId;
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/web/mapeos/EmpleadoConceptoProjectionMapper.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/web/mapeos/EmpleadoConceptoProjectionMapper.java
@@ -1,0 +1,13 @@
+package ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos;
+
+import ar.org.hospitalcuencaalta.servicio_consultas.proyecciones.EmpleadoConceptoProjection;
+import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.EmpleadoConceptoDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface EmpleadoConceptoProjectionMapper {
+    @Mapping(target = "empleado.id", source = "empleadoId")
+    @Mapping(target = "concepto.id", source = "conceptoId")
+    EmpleadoConceptoProjection toEmpleadoConcepto(EmpleadoConceptoDto dto);
+}

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/EmpleadoConceptoController.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/EmpleadoConceptoController.java
@@ -1,6 +1,7 @@
 package ar.org.hospitalcuencaalta.servicio_nomina.controlador;
 
 import ar.org.hospitalcuencaalta.servicio_nomina.servicio.EmpleadoConceptoService;
+import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.EmpleadoConceptoDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +15,7 @@ public class EmpleadoConceptoController {
     private EmpleadoConceptoService svc;
 
     @PostMapping("/{conceptoId}")
-    public void asignar(@PathVariable Long empleadoId, @PathVariable Long conceptoId) {
-        svc.asignarConcepto(empleadoId, conceptoId);
+    public EmpleadoConceptoDto asignar(@PathVariable Long empleadoId, @PathVariable Long conceptoId) {
+        return svc.asignarConcepto(empleadoId, conceptoId);
     }
 }

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/repositorio/EmpleadoRegistryRepository.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/repositorio/EmpleadoRegistryRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmpleadoRegistryRepository extends JpaRepository<EmpleadoRegistry,Long> {
     boolean existsByIdAndDocumento(Long id, String documento);
+    boolean existsByDocumento(String documento);
 }

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/servicio/LiquidacionService.java
@@ -73,8 +73,10 @@ public class LiquidacionService {
         }
 
         if (!empleadoRegistryRepo.existsByIdAndDocumento(emp.getId(), emp.getDocumento())) {
-            // Sincronizamos la información del empleado localmente para futuras operaciones,
-            // pero permitimos continuar sin rechazar la creación de la liquidación.
+            if (empleadoRegistryRepo.existsByDocumento(emp.getDocumento())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "Ya existe un empleado con documento " + emp.getDocumento());
+            }
             empleadoRegistryRepo.save(EmpleadoRegistry.builder()
                     .id(emp.getId())
                     .documento(emp.getDocumento())

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/web/dto/EmpleadoConceptoDto.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/web/dto/EmpleadoConceptoDto.java
@@ -1,0 +1,16 @@
+package ar.org.hospitalcuencaalta.servicio_nomina.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmpleadoConceptoDto {
+    private Long id;
+    private Long empleadoId;
+    private Long conceptoId;
+}


### PR DESCRIPTION
## Summary
- add DTO and event listener for employee concept assignments
- publish Kafka event when asigning concepts
- prevent duplicate employee documents when generating payroll
- expose employee concept result in controller

## Testing
- `./mvnw -q -pl servicio-nomina -am test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6863c60c4fd8832489ef495a52b6c06f