### PR TITLE
Corregir los oyentes de nómina de Kafka

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ConceptoLiquidacionEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ConceptoLiquidacionEventListener.java
@@ -1,6 +1,7 @@
 package ar.org.hospitalcuencaalta.servicio_consultas.evento;
 
 import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.ConceptoLiquidacionProjectionRepository;
+import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.LiquidacionProjectionRepository;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.ConceptoLiquidacionDto;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.ConceptoLiquidacionProjectionMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,9 +14,13 @@ public class ConceptoLiquidacionEventListener {
     private ConceptoLiquidacionProjectionRepository repo;
     @Autowired
     private ConceptoLiquidacionProjectionMapper mapper;
+    @Autowired
+    private LiquidacionProjectionRepository liquidacionRepo;
 
     @KafkaListener(topics = "servicioNomina.added")
     public void onCreated(ConceptoLiquidacionDto dto) {
-        repo.save(mapper.toConcepto(dto));
+        var concepto = mapper.toConcepto(dto);
+        concepto.setLiquidacion(liquidacionRepo.getReferenceById(dto.getLiquidacionId()));
+        repo.save(concepto);
     }
 }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoConceptoEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/EmpleadoConceptoEventListener.java
@@ -1,6 +1,8 @@
 package ar.org.hospitalcuencaalta.servicio_consultas.evento;
 
+import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.ConceptoLiquidacionProjectionRepository;
 import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.EmpleadoConceptoProjectionRepository;
+import ar.org.hospitalcuencaalta.servicio_consultas.repositorio.EmpleadoProjectionRepository;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.dto.EmpleadoConceptoDto;
 import ar.org.hospitalcuencaalta.servicio_consultas.web.mapeos.EmpleadoConceptoProjectionMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,9 +13,14 @@ import org.springframework.stereotype.Component;
 public class EmpleadoConceptoEventListener {
     @Autowired private EmpleadoConceptoProjectionRepository repo;
     @Autowired private EmpleadoConceptoProjectionMapper mapper;
+    @Autowired private EmpleadoProjectionRepository empleadoRepo;
+    @Autowired private ConceptoLiquidacionProjectionRepository conceptoRepo;
 
     @KafkaListener(topics = "servicioNomina.empleadoConcepto.created")
     public void onCreated(EmpleadoConceptoDto dto) {
-        repo.save(mapper.toEmpleadoConcepto(dto));
+        var ec = mapper.toEmpleadoConcepto(dto);
+        ec.setEmpleado(empleadoRepo.getReferenceById(dto.getEmpleadoId()));
+        ec.setConcepto(conceptoRepo.getReferenceById(dto.getConceptoId()));
+        repo.save(ec);
     }
 }


### PR DESCRIPTION
## Summary
- use repository references when persisting ConceptoLiquidacionProjection
- use repository references when persisting EmpleadoConceptoProjection

## Testing
- `./mvnw -B -q -pl servicio-consultas test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6863d7d379dc8324a26d13c2e24369f5