### PR TITLE
Fix concept listener null check

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ConceptoLiquidacionEventListener.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/evento/ConceptoLiquidacionEventListener.java
@@ -20,7 +20,11 @@ public class ConceptoLiquidacionEventListener {
     @KafkaListener(topics = "servicioNomina.added")
     public void onCreated(ConceptoLiquidacionDto dto) {
         var concepto = mapper.toConcepto(dto);
-        concepto.setLiquidacion(liquidacionRepo.getReferenceById(dto.getLiquidacionId()));
+        if (dto.getLiquidacionId() != null) {
+            concepto.setLiquidacion(liquidacionRepo.getReferenceById(dto.getLiquidacionId()));
+        } else {
+            concepto.setLiquidacion(null);
+        }
         repo.save(concepto);
     }
 }


### PR DESCRIPTION
## Summary
- avoid failing when liquidacionId is missing in concepto events

## Testing
- `mvn test` *(fails: Could not resolve dependencies due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6863da4975c88324b9196422c6470f41