### PR TITLE
Fix cb-state endpoint through gateway

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -199,6 +199,12 @@ spring.cloud.gateway.server.webflux.routes[23].uri=lb://servicio-orquestador
 spring.cloud.gateway.server.webflux.routes[23].predicates[0]=Path=/api/saga/**
 spring.cloud.gateway.server.webflux.routes[23].predicates[1]=Method=GET
 
+# 13. Circuit Breaker status endpoints expuestos por el orquestador
+spring.cloud.gateway.server.webflux.routes[25].id=orquestador-cbstate
+spring.cloud.gateway.server.webflux.routes[25].uri=lb://servicio-orquestador
+spring.cloud.gateway.server.webflux.routes[25].predicates[0]=Path=/actuator/cb-state/**
+spring.cloud.gateway.server.webflux.routes[25].predicates[1]=Method=GET
+
 
 logging.level.org.springframework.cloud.gateway.discovery=DEBUG
 logging.level.org.springframework.cloud.gateway.route=DEBUG


### PR DESCRIPTION
## Summary
- add gateway routing so `/actuator/cb-state/**` hits `servicio-orquestador`

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: `NullPointerException: Cannot invoke "String.lastIndexOf(String)" because "path" is null`)*

------
https://chatgpt.com/codex/tasks/task_e_68651141a8908324927879f556153787