### PR TITLE
Corregir la sintaxis de plantuml y agregar más diagramas

### DIFF
--- a/docs/uml/global/activity/payroll_process.puml
+++ b/docs/uml/global/activity/payroll_process.puml
@@ -1,8 +1,8 @@
 @startuml
 start
-:empleado service sends event;
-:contrato service creates contract;
-:nomina service generates payroll;
-:consultas service updates projections;
+:servicio empleado envía evento;
+:servicio contrato crea contrato;
+:servicio nomina genera nómina;
+:servicio consultas actualiza proyecciones;
 stop
 @enduml

--- a/docs/uml/global/sequence/empleado_event_flow.puml
+++ b/docs/uml/global/sequence/empleado_event_flow.puml
@@ -1,8 +1,8 @@
 @startuml
 actor ServicioEmpleado
 ServicioEmpleado -> Kafka : empleado.created
-Kafka -> servicio-contrato : empleado.created
-Kafka -> servicio-nomina : empleado.created
-Kafka -> servicio-entrenamiento : empleado.created
-Kafka -> servicio-consultas : empleado.created
+Kafka -> "servicio-contrato" : empleado.created
+Kafka -> "servicio-nomina" : empleado.created
+Kafka -> "servicio-entrenamiento" : empleado.created
+Kafka -> "servicio-consultas" : empleado.created
 @enduml

--- a/docs/uml/global/sequence/evaluacion_event_flow.puml
+++ b/docs/uml/global/sequence/evaluacion_event_flow.puml
@@ -1,0 +1,5 @@
+@startuml
+actor ServicioEntrenamiento
+ServicioEntrenamiento -> Kafka : servicioEntrenamiento.evaluated
+Kafka -> "servicio-consultas" : servicioEntrenamiento.evaluated
+@enduml

--- a/docs/uml/global/sequence/gateway_route_flow.puml
+++ b/docs/uml/global/sequence/gateway_route_flow.puml
@@ -1,0 +1,10 @@
+@startuml
+actor Cliente
+Cliente -> API_Gateway : solicitud HTTP
+API_Gateway -> "servicio-empleado" : /api/empleados
+API_Gateway -> "servicio-contrato" : /api/contratos
+API_Gateway -> "servicio-nomina" : /api/liquidaciones
+API_Gateway -> "servicio-entrenamiento" : /api/evaluaciones
+API_Gateway -> "servicio-consultas" : /api/consultas
+API_Gateway -> "servicio-orquestador" : /api/saga
+@enduml

--- a/docs/uml/global/sequence/nomina_event_flow.puml
+++ b/docs/uml/global/sequence/nomina_event_flow.puml
@@ -1,0 +1,5 @@
+@startuml
+actor ServicioNomina
+ServicioNomina -> Kafka : servicioNomina.nomina.generated
+Kafka -> "servicio-consultas" : servicioNomina.nomina.generated
+@enduml

--- a/docs/uml/global/sequence/saga_create_sequence.puml
+++ b/docs/uml/global/sequence/saga_create_sequence.puml
@@ -1,10 +1,10 @@
 @startuml
 actor Client
 Client -> API_Gateway : POST /api/saga
-API_Gateway -> servicio-orquestador : request
-servicio-orquestador -> servicio-empleado : create employee
-servicio-empleado --> servicio-orquestador : empleado dto
-servicio-orquestador -> servicio-contrato : create contrato
-servicio-contrato --> servicio-orquestador : contrato dto
-servicio-orquestador -> Kafka : publish saga completed
+API_Gateway -> "servicio-orquestador" : solicitud
+"servicio-orquestador" -> "servicio-empleado" : crear empleado
+"servicio-empleado" --> "servicio-orquestador" : empleado dto
+"servicio-orquestador" -> "servicio-contrato" : crear contrato
+"servicio-contrato" --> "servicio-orquestador" : contrato dto
+"servicio-orquestador" -> Kafka : publicar saga completed
 @enduml

--- a/servicio-consultas/docs/uml/local/sequence/kafka_ingest_sequence.puml
+++ b/servicio-consultas/docs/uml/local/sequence/kafka_ingest_sequence.puml
@@ -1,6 +1,6 @@
 @startuml
 actor Kafka
 Kafka -> ContratoEventListener : contrato.created
-ContratoEventListener -> ContratoProjectionRepository : save
+ContratoEventListener -> ContratoProjectionRepository : guardar
 ContratoProjectionRepository --> ContratoEventListener : ok
 @enduml

--- a/servicio-consultas/docs/uml/local/sequence/query_projection_sequence.puml
+++ b/servicio-consultas/docs/uml/local/sequence/query_projection_sequence.puml
@@ -1,0 +1,7 @@
+@startuml
+actor Client
+Client -> ProyeccionController : GET /api/proyecciones/{id}
+ProyeccionController -> ProyeccionRepository : findById
+ProyeccionRepository --> ProyeccionController : entidad
+ProyeccionController --> Client : 200 OK
+@enduml

--- a/servicio-contrato/docs/uml/local/sequence/delete_contract_sequence.puml
+++ b/servicio-contrato/docs/uml/local/sequence/delete_contract_sequence.puml
@@ -1,0 +1,7 @@
+@startuml
+actor Client
+Client -> ContratoController : DELETE /api/contratos/{id}
+ContratoController -> ContratoService : eliminar(id)
+ContratoService -> ContratoLaboralRepository : deleteById
+ContratoController --> Client : 204 No Content
+@enduml

--- a/servicio-contrato/docs/uml/local/sequence/get_contract_sequence.puml
+++ b/servicio-contrato/docs/uml/local/sequence/get_contract_sequence.puml
@@ -1,0 +1,9 @@
+@startuml
+actor Client
+Client -> ContratoController : GET /api/contratos/{id}
+ContratoController -> ContratoService : buscarPorId(id)
+ContratoService -> ContratoLaboralRepository : findById
+ContratoLaboralRepository --> ContratoService : entidad
+ContratoService --> ContratoController : dto
+ContratoController --> Client : 200 OK
+@enduml

--- a/servicio-contrato/docs/uml/local/sequence/update_contract_sequence.puml
+++ b/servicio-contrato/docs/uml/local/sequence/update_contract_sequence.puml
@@ -1,11 +1,11 @@
 @startuml
 actor Client
-Client -> ContratoController : POST /api/contratos
-ContratoController -> ContratoService : crear(dto)
+Client -> ContratoController : PUT /api/contratos/{id}
+ContratoController -> ContratoService : actualizar(id,dto)
 ContratoService -> EmpleadoClient : getById
 EmpleadoClient --> ContratoService : EmpleadoRegistryDto
 ContratoService -> ContratoLaboralRepository : guardar(entidad)
 ContratoLaboralRepository --> ContratoService : entidad
 ContratoService --> ContratoController : dto
-ContratoController --> Client : 201 Created
+ContratoController --> Client : 200 OK
 @enduml

--- a/servicio-empleado/docs/uml/local/sequence/create_empleado_sequence.puml
+++ b/servicio-empleado/docs/uml/local/sequence/create_empleado_sequence.puml
@@ -1,10 +1,10 @@
 @startuml
 actor Client
 Client -> EmpleadoController : POST /api/empleados
-EmpleadoController -> EmpleadoService : create(dto)
-EmpleadoService -> EmpleadoRepository : save
+EmpleadoController -> EmpleadoService : crear(dto)
+EmpleadoService -> EmpleadoRepository : guardar
 EmpleadoRepository --> EmpleadoService : entidad
-EmpleadoService -> EmpleadoEventPublisher : publishCreated
+EmpleadoService -> EmpleadoEventPublisher : publicarCreado
 EmpleadoService --> EmpleadoController : dto
 EmpleadoController --> Client : 201 Created
 @enduml

--- a/servicio-empleado/docs/uml/local/sequence/delete_empleado_sequence.puml
+++ b/servicio-empleado/docs/uml/local/sequence/delete_empleado_sequence.puml
@@ -1,0 +1,8 @@
+@startuml
+actor Client
+Client -> EmpleadoController : DELETE /api/empleados/{id}
+EmpleadoController -> EmpleadoService : eliminar(id)
+EmpleadoService -> EmpleadoRepository : deleteById
+EmpleadoService -> EmpleadoEventPublisher : publicarEliminado
+EmpleadoController --> Client : 204 No Content
+@enduml

--- a/servicio-empleado/docs/uml/local/sequence/get_empleado_sequence.puml
+++ b/servicio-empleado/docs/uml/local/sequence/get_empleado_sequence.puml
@@ -1,0 +1,9 @@
+@startuml
+actor Client
+Client -> EmpleadoController : GET /api/empleados/{id}
+EmpleadoController -> EmpleadoService : buscarPorId(id)
+EmpleadoService -> EmpleadoRepository : findById
+EmpleadoRepository --> EmpleadoService : entidad
+EmpleadoService --> EmpleadoController : dto
+EmpleadoController --> Client : 200 OK
+@enduml

--- a/servicio-empleado/docs/uml/local/sequence/update_empleado_sequence.puml
+++ b/servicio-empleado/docs/uml/local/sequence/update_empleado_sequence.puml
@@ -1,0 +1,10 @@
+@startuml
+actor Client
+Client -> EmpleadoController : PUT /api/empleados/{id}
+EmpleadoController -> EmpleadoService : actualizar(id,dto)
+EmpleadoService -> EmpleadoRepository : guardar
+EmpleadoRepository --> EmpleadoService : entidad
+EmpleadoService -> EmpleadoEventPublisher : publicarActualizado
+EmpleadoService --> EmpleadoController : dto
+EmpleadoController --> Client : 200 OK
+@enduml

--- a/servicio-entrenamiento/docs/uml/local/sequence/create_evaluacion_sequence.puml
+++ b/servicio-entrenamiento/docs/uml/local/sequence/create_evaluacion_sequence.puml
@@ -1,12 +1,12 @@
 @startuml
 actor Client
 Client -> EvaluacionController : POST /api/evaluaciones
-EvaluacionController -> EvaluacionService : create(dto)
+EvaluacionController -> EvaluacionService : crear(dto)
 EvaluacionService -> EmpleadoClient : getById
 EmpleadoClient --> EvaluacionService : EmpleadoRegistryDto
-EvaluacionService -> EvaluacionDesempenoRepository : save
+EvaluacionService -> EvaluacionDesempenoRepository : guardar
 EvaluacionDesempenoRepository --> EvaluacionService : entity
-EvaluacionService -> Kafka : send evaluated
+EvaluacionService -> Kafka : send servicioEntrenamiento.evaluated
 EvaluacionService --> EvaluacionController : dto
 EvaluacionController --> Client : 201 Created
 @enduml

--- a/servicio-entrenamiento/docs/uml/local/sequence/delete_evaluacion_sequence.puml
+++ b/servicio-entrenamiento/docs/uml/local/sequence/delete_evaluacion_sequence.puml
@@ -1,0 +1,7 @@
+@startuml
+actor Client
+Client -> EvaluacionController : DELETE /api/evaluaciones/{id}
+EvaluacionController -> EvaluacionService : eliminar(id)
+EvaluacionService -> EvaluacionDesempenoRepository : deleteById
+EvaluacionController --> Client : 204 No Content
+@enduml

--- a/servicio-entrenamiento/docs/uml/local/sequence/get_evaluacion_sequence.puml
+++ b/servicio-entrenamiento/docs/uml/local/sequence/get_evaluacion_sequence.puml
@@ -1,0 +1,9 @@
+@startuml
+actor Client
+Client -> EvaluacionController : GET /api/evaluaciones/{id}
+EvaluacionController -> EvaluacionService : buscarPorId(id)
+EvaluacionService -> EvaluacionDesempenoRepository : findById
+EvaluacionDesempenoRepository --> EvaluacionService : entity
+EvaluacionService --> EvaluacionController : dto
+EvaluacionController --> Client : 200 OK
+@enduml

--- a/servicio-entrenamiento/docs/uml/local/sequence/update_evaluacion_sequence.puml
+++ b/servicio-entrenamiento/docs/uml/local/sequence/update_evaluacion_sequence.puml
@@ -1,0 +1,9 @@
+@startuml
+actor Client
+Client -> EvaluacionController : PUT /api/evaluaciones/{id}
+EvaluacionController -> EvaluacionService : actualizar(id,dto)
+EvaluacionService -> EvaluacionDesempenoRepository : guardar
+EvaluacionDesempenoRepository --> EvaluacionService : entity
+EvaluacionService --> EvaluacionController : dto
+EvaluacionController --> Client : 200 OK
+@enduml

--- a/servicio-nomina/docs/uml/local/sequence/create_liquidacion_sequence.puml
+++ b/servicio-nomina/docs/uml/local/sequence/create_liquidacion_sequence.puml
@@ -1,10 +1,10 @@
 @startuml
 actor Client
 Client -> LiquidacionController : POST /api/liquidaciones
-LiquidacionController -> LiquidacionService : create(dto)
+LiquidacionController -> LiquidacionService : crear(dto)
 LiquidacionService -> EmpleadoClient : getById
 EmpleadoClient --> LiquidacionService : EmpleadoRegistryDto
-LiquidacionService -> LiquidacionRepository : save
+LiquidacionService -> LiquidacionRepository : guardar
 LiquidacionRepository --> LiquidacionService : entity
 LiquidacionService -> Kafka : send nomina.generated
 LiquidacionService --> LiquidacionController : dto

--- a/servicio-nomina/docs/uml/local/sequence/delete_liquidacion_sequence.puml
+++ b/servicio-nomina/docs/uml/local/sequence/delete_liquidacion_sequence.puml
@@ -1,0 +1,7 @@
+@startuml
+actor Client
+Client -> LiquidacionController : DELETE /api/liquidaciones/{id}
+LiquidacionController -> LiquidacionService : eliminar(id)
+LiquidacionService -> LiquidacionRepository : deleteById
+LiquidacionController --> Client : 204 No Content
+@enduml

--- a/servicio-nomina/docs/uml/local/sequence/get_liquidacion_sequence.puml
+++ b/servicio-nomina/docs/uml/local/sequence/get_liquidacion_sequence.puml
@@ -1,0 +1,9 @@
+@startuml
+actor Client
+Client -> LiquidacionController : GET /api/liquidaciones/{id}
+LiquidacionController -> LiquidacionService : buscarPorId(id)
+LiquidacionService -> LiquidacionRepository : findById
+LiquidacionRepository --> LiquidacionService : entity
+LiquidacionService --> LiquidacionController : dto
+LiquidacionController --> Client : 200 OK
+@enduml

--- a/servicio-nomina/docs/uml/local/sequence/update_liquidacion_sequence.puml
+++ b/servicio-nomina/docs/uml/local/sequence/update_liquidacion_sequence.puml
@@ -1,0 +1,9 @@
+@startuml
+actor Client
+Client -> LiquidacionController : PUT /api/liquidaciones/{id}
+LiquidacionController -> LiquidacionService : actualizar(id,dto)
+LiquidacionService -> LiquidacionRepository : guardar
+LiquidacionRepository --> LiquidacionService : entity
+LiquidacionService --> LiquidacionController : dto
+LiquidacionController --> Client : 200 OK
+@enduml

--- a/servicio-orquestador/docs/uml/local/sequence/saga_create_sequence.puml
+++ b/servicio-orquestador/docs/uml/local/sequence/saga_create_sequence.puml
@@ -1,11 +1,11 @@
 @startuml
 actor Client
 Client -> SagaController : POST /api/saga
-SagaController -> SagaStateMachine : start
-SagaStateMachine -> EmpleadoClient : create
+SagaController -> SagaStateMachine : iniciar
+SagaStateMachine -> EmpleadoClient : crear
 EmpleadoClient --> SagaStateMachine : EmpleadoDto
-SagaStateMachine -> ContratoClient : create
+SagaStateMachine -> ContratoClient : crear
 ContratoClient --> SagaStateMachine : ContratoDto
-SagaStateMachine -> DomainEventPublisher : publish events
-SagaController --> Client : result
+SagaStateMachine -> DomainEventPublisher : publicar eventos
+SagaController --> Client : resultado
 @enduml

--- a/servicio-orquestador/docs/uml/local/sequence/saga_delete_sequence.puml
+++ b/servicio-orquestador/docs/uml/local/sequence/saga_delete_sequence.puml
@@ -1,0 +1,8 @@
+@startuml
+actor Client
+Client -> SagaController : DELETE /empleado-contrato/{id}?contratoId={cid}
+SagaController -> SagaStateMachine : eliminar
+SagaStateMachine -> EmpleadoClient : delete
+SagaStateMachine -> ContratoClient : delete
+SagaController --> Client : resultado
+@enduml

--- a/servicio-orquestador/docs/uml/local/sequence/saga_get_sequence.puml
+++ b/servicio-orquestador/docs/uml/local/sequence/saga_get_sequence.puml
@@ -1,0 +1,7 @@
+@startuml
+actor Client
+Client -> SagaController : GET /empleado-contrato/{id}
+SagaController -> SagaStateService : findById
+SagaStateService --> SagaController : SagaStatusResponse
+SagaController --> Client : 200 OK
+@enduml

--- a/servicio-orquestador/docs/uml/local/sequence/saga_update_sequence.puml
+++ b/servicio-orquestador/docs/uml/local/sequence/saga_update_sequence.puml
@@ -1,0 +1,8 @@
+@startuml
+actor Client
+Client -> SagaController : PUT /empleado-contrato/{id}
+SagaController -> SagaStateMachine : actualizar
+SagaStateMachine -> EmpleadoClient : update
+SagaStateMachine -> ContratoClient : update
+SagaController --> Client : resultado
+@enduml


### PR DESCRIPTION
## Summary
- corrige errores de sintaxis en los diagramas de secuencia globales
- traduce acciones al español en varios diagramas
- agrega diagramas de flujo de eventos y de ruteo de API Gateway
- añade diagramas CRUD para cada microservicio

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_68665482e88083248fff58a6be93994f