### PR TITLE
Corregir el servidor de descubrimiento pom padre

### DIFF
--- a/servidor-para-descubrimiento/pom.xml
+++ b/servidor-para-descubrimiento/pom.xml
@@ -3,10 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>ar.org.hospitalcuencaalta</groupId>
+        <artifactId>rrhh</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>ar.org.hospitalcuencaalta</groupId>
@@ -64,13 +63,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-dependencies</artifactId>
-            <version>${spring-cloud.version}</version>
-            <type>pom</type>
-            <scope>runtime</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
## Summary
- use main `rrhh` pom as the parent for `servidor-para-descubrimiento`
- remove redundant dependency management

## Testing
- `./mvnw -q -DskipTests=true clean package` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6866c4d9ca2483249ba6bf716ea84f6b