### PR TITLE
Reparar el inicio del servidor Eureka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
## Summary
- set Spring Boot parent version to 3.4.5 for compatibility with the Spring Cloud release train

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866cacf72688324950a86f51e801c9a