### PR TITLE
Actualizar Spring Boot a 3.5.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,7 @@ más relevantes son:
 * `java.version` -> 17
 * `spring-cloud.version` -> 2025.0.0
 * `require.maven.version` -> 3.9.9
-* `actuator.version` -> 3.4.5
+* `actuator.version` -> 3.5.1
 
 Desde la raíz del repositorio podés compilar todos los módulos a la vez:
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.5.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -74,7 +74,7 @@
         <io.github.classgraph.version>4.8.173</io.github.classgraph.version>
         <webjars.version>4.15.5</webjars.version>
         <fasterxml.woodstox.version>7.0.0</fasterxml.woodstox.version>
-        <actuator.version>3.4.5</actuator.version>
+        <actuator.version>3.5.1</actuator.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- bump Spring Boot parent version
- update actuator version in README and pom

## Testing
- `mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6866e67aa65c8324970f6efe70f7548e