### PR TITLE
Corregir el prefijo de propiedades de la puerta de enlace de API

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -11,9 +11,9 @@ eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka
 spring.cloud.discovery.enabled=true
 
 # Habilita la generación dinámica de rutas a partir de los servicios registrados
-spring.cloud.gateway.discovery.locator.enabled=true
+spring.cloud.gateway.server.webflux.discovery.locator.enabled=true
 # para rutas con minúsculas
-spring.cloud.gateway.discovery.locator.lower-case-service-id=true
+spring.cloud.gateway.server.webflux.discovery.locator.lower-case-service-id=true
 
 
 #eureka.client.register-with-eureka=true
@@ -22,9 +22,9 @@ spring.cloud.gateway.discovery.locator.lower-case-service-id=true
 eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}
 
 # CORS Global
-spring.cloud.gateway.globalcors.cors-configurations.[/**].allowed-origins=*
-spring.cloud.gateway.globalcors.cors-configurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
-spring.cloud.gateway.globalcors.cors-configurations.[/**].allowed-headers=*
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-origins=*
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
+spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-headers=*
 
 # =============================================================
 # Routes: Escritura (POST, PUT, DELETE) → servicios del dominio
@@ -32,178 +32,178 @@ spring.cloud.gateway.globalcors.cors-configurations.[/**].allowed-headers=*
 # =============================================================
 
 # 0. Empleado
-spring.cloud.gateway.routes[0].id=empleado-write
-spring.cloud.gateway.routes[0].uri=lb://servicio-empleado
-spring.cloud.gateway.routes[0].predicates[0]=Path=/api/empleados/**
-spring.cloud.gateway.routes[0].predicates[1]=Method=POST
-spring.cloud.gateway.routes[0].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[0].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[0].id=empleado-write
+spring.cloud.gateway.server.webflux.routes[0].uri=lb://servicio-empleado
+spring.cloud.gateway.server.webflux.routes[0].predicates[0]=Path=/api/empleados/**
+spring.cloud.gateway.server.webflux.routes[0].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[0].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[0].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[1].id=empleado-read
-spring.cloud.gateway.routes[1].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[1].predicates[0]=Path=/api/empleados/**
-spring.cloud.gateway.routes[1].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[1].id=empleado-read
+spring.cloud.gateway.server.webflux.routes[1].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[1].predicates[0]=Path=/api/empleados/**
+spring.cloud.gateway.server.webflux.routes[1].predicates[1]=Method=GET
 
 # 1. Contrato
-spring.cloud.gateway.routes[2].id=contrato-write
-spring.cloud.gateway.routes[2].uri=lb://servicio-contrato
-spring.cloud.gateway.routes[2].predicates[0]=Path=/api/contratos/**
-spring.cloud.gateway.routes[2].predicates[1]=Method=POST
-spring.cloud.gateway.routes[2].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[2].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[2].id=contrato-write
+spring.cloud.gateway.server.webflux.routes[2].uri=lb://servicio-contrato
+spring.cloud.gateway.server.webflux.routes[2].predicates[0]=Path=/api/contratos/**
+spring.cloud.gateway.server.webflux.routes[2].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[2].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[2].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[3].id=contrato-read
-spring.cloud.gateway.routes[3].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[3].predicates[0]=Path=/api/contratos/**
-spring.cloud.gateway.routes[3].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[3].id=contrato-read
+spring.cloud.gateway.server.webflux.routes[3].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[3].predicates[0]=Path=/api/contratos/**
+spring.cloud.gateway.server.webflux.routes[3].predicates[1]=Method=GET
 
 # 2. Jornada
-spring.cloud.gateway.routes[4].id=jornada-write
-spring.cloud.gateway.routes[4].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.routes[4].predicates[0]=Path=/api/jornadas/**
-spring.cloud.gateway.routes[4].predicates[1]=Method=POST
-spring.cloud.gateway.routes[4].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[4].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[4].id=jornada-write
+spring.cloud.gateway.server.webflux.routes[4].uri=lb://servicio-entrenamiento
+spring.cloud.gateway.server.webflux.routes[4].predicates[0]=Path=/api/jornadas/**
+spring.cloud.gateway.server.webflux.routes[4].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[4].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[4].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[5].id=jornada-read
-spring.cloud.gateway.routes[5].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[5].predicates[0]=Path=/api/jornadas/**
-spring.cloud.gateway.routes[5].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[5].id=jornada-read
+spring.cloud.gateway.server.webflux.routes[5].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[5].predicates[0]=Path=/api/jornadas/**
+spring.cloud.gateway.server.webflux.routes[5].predicates[1]=Method=GET
 
 # 3. Turno
-spring.cloud.gateway.routes[6].id=turno-write
-spring.cloud.gateway.routes[6].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.routes[6].predicates[0]=Path=/api/turnos/**
-spring.cloud.gateway.routes[6].predicates[1]=Method=POST
-spring.cloud.gateway.routes[6].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[6].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[6].id=turno-write
+spring.cloud.gateway.server.webflux.routes[6].uri=lb://servicio-entrenamiento
+spring.cloud.gateway.server.webflux.routes[6].predicates[0]=Path=/api/turnos/**
+spring.cloud.gateway.server.webflux.routes[6].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[6].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[6].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[7].id=turno-read
-spring.cloud.gateway.routes[7].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[7].predicates[0]=Path=/api/turnos/**
-spring.cloud.gateway.routes[7].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[7].id=turno-read
+spring.cloud.gateway.server.webflux.routes[7].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[7].predicates[0]=Path=/api/turnos/**
+spring.cloud.gateway.server.webflux.routes[7].predicates[1]=Method=GET
 
 # 4. Asistencia
-spring.cloud.gateway.routes[8].id=asistencia-write
-spring.cloud.gateway.routes[8].uri=lb://servicio-contrato
-spring.cloud.gateway.routes[8].predicates[0]=Path=/api/asistencias/**
-spring.cloud.gateway.routes[8].predicates[1]=Method=POST
-spring.cloud.gateway.routes[8].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[8].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[8].id=asistencia-write
+spring.cloud.gateway.server.webflux.routes[8].uri=lb://servicio-contrato
+spring.cloud.gateway.server.webflux.routes[8].predicates[0]=Path=/api/asistencias/**
+spring.cloud.gateway.server.webflux.routes[8].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[8].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[8].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[9].id=asistencia-read
-spring.cloud.gateway.routes[9].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[9].predicates[0]=Path=/api/asistencias/**
-spring.cloud.gateway.routes[9].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[9].id=asistencia-read
+spring.cloud.gateway.server.webflux.routes[9].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[9].predicates[0]=Path=/api/asistencias/**
+spring.cloud.gateway.server.webflux.routes[9].predicates[1]=Method=GET
 
 # 5. Licencia
-spring.cloud.gateway.routes[10].id=licencia-write
-spring.cloud.gateway.routes[10].uri=lb://servicio-contrato
-spring.cloud.gateway.routes[10].predicates[0]=Path=/api/licencias/**
-spring.cloud.gateway.routes[10].predicates[1]=Method=POST
-spring.cloud.gateway.routes[10].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[10].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[10].id=licencia-write
+spring.cloud.gateway.server.webflux.routes[10].uri=lb://servicio-contrato
+spring.cloud.gateway.server.webflux.routes[10].predicates[0]=Path=/api/licencias/**
+spring.cloud.gateway.server.webflux.routes[10].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[10].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[10].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[11].id=licencia-read
-spring.cloud.gateway.routes[11].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[11].predicates[0]=Path=/api/licencias/**
-spring.cloud.gateway.routes[11].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[11].id=licencia-read
+spring.cloud.gateway.server.webflux.routes[11].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[11].predicates[0]=Path=/api/licencias/**
+spring.cloud.gateway.server.webflux.routes[11].predicates[1]=Method=GET
 
 # 6. Vacación
-spring.cloud.gateway.routes[12].id=vacacion-write
-spring.cloud.gateway.routes[12].uri=lb://servicio-contrato
-spring.cloud.gateway.routes[12].predicates[0]=Path=/api/vacaciones/**
-spring.cloud.gateway.routes[12].predicates[1]=Method=POST
-spring.cloud.gateway.routes[12].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[12].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[12].id=vacacion-write
+spring.cloud.gateway.server.webflux.routes[12].uri=lb://servicio-contrato
+spring.cloud.gateway.server.webflux.routes[12].predicates[0]=Path=/api/vacaciones/**
+spring.cloud.gateway.server.webflux.routes[12].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[12].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[12].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[13].id=vacacion-read
-spring.cloud.gateway.routes[13].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[13].predicates[0]=Path=/api/vacaciones/**
-spring.cloud.gateway.routes[13].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[13].id=vacacion-read
+spring.cloud.gateway.server.webflux.routes[13].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[13].predicates[0]=Path=/api/vacaciones/**
+spring.cloud.gateway.server.webflux.routes[13].predicates[1]=Method=GET
 
 # 7. Capacitación
-spring.cloud.gateway.routes[14].id=capacitacion-write
-spring.cloud.gateway.routes[14].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.routes[14].predicates[0]=Path=/api/capacitaciones/**
-spring.cloud.gateway.routes[14].predicates[1]=Method=POST
-spring.cloud.gateway.routes[14].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[14].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[14].id=capacitacion-write
+spring.cloud.gateway.server.webflux.routes[14].uri=lb://servicio-entrenamiento
+spring.cloud.gateway.server.webflux.routes[14].predicates[0]=Path=/api/capacitaciones/**
+spring.cloud.gateway.server.webflux.routes[14].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[14].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[14].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[15].id=capacitacion-read
-spring.cloud.gateway.routes[15].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[15].predicates[0]=Path=/api/capacitaciones/**
-spring.cloud.gateway.routes[15].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[15].id=capacitacion-read
+spring.cloud.gateway.server.webflux.routes[15].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[15].predicates[0]=Path=/api/capacitaciones/**
+spring.cloud.gateway.server.webflux.routes[15].predicates[1]=Method=GET
 
 # 8. Evaluación
-spring.cloud.gateway.routes[16].id=evaluacion-write
-spring.cloud.gateway.routes[16].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.routes[16].predicates[0]=Path=/api/evaluaciones/**
-spring.cloud.gateway.routes[16].predicates[1]=Method=POST
-spring.cloud.gateway.routes[16].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[16].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[16].id=evaluacion-write
+spring.cloud.gateway.server.webflux.routes[16].uri=lb://servicio-entrenamiento
+spring.cloud.gateway.server.webflux.routes[16].predicates[0]=Path=/api/evaluaciones/**
+spring.cloud.gateway.server.webflux.routes[16].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[16].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[16].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[17].id=evaluacion-read
-spring.cloud.gateway.routes[17].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[17].predicates[0]=Path=/api/evaluaciones/**
-spring.cloud.gateway.routes[17].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[17].id=evaluacion-read
+spring.cloud.gateway.server.webflux.routes[17].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[17].predicates[0]=Path=/api/evaluaciones/**
+spring.cloud.gateway.server.webflux.routes[17].predicates[1]=Method=GET
 
 # 9. Liquidación
-spring.cloud.gateway.routes[18].id=liquidacion-write
-spring.cloud.gateway.routes[18].uri=lb://servicio-nomina
-spring.cloud.gateway.routes[18].predicates[0]=Path=/api/liquidaciones/**
-spring.cloud.gateway.routes[18].predicates[1]=Method=POST
-spring.cloud.gateway.routes[18].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[18].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[18].id=liquidacion-write
+spring.cloud.gateway.server.webflux.routes[18].uri=lb://servicio-nomina
+spring.cloud.gateway.server.webflux.routes[18].predicates[0]=Path=/api/liquidaciones/**
+spring.cloud.gateway.server.webflux.routes[18].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[18].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[18].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[19].id=liquidacion-read
-spring.cloud.gateway.routes[19].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[19].predicates[0]=Path=/api/liquidaciones/**
-spring.cloud.gateway.routes[19].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[19].id=liquidacion-read
+spring.cloud.gateway.server.webflux.routes[19].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[19].predicates[0]=Path=/api/liquidaciones/**
+spring.cloud.gateway.server.webflux.routes[19].predicates[1]=Method=GET
 
 # 10. Concepto de Liquidación
-spring.cloud.gateway.routes[20].id=concepto-write
-spring.cloud.gateway.routes[20].uri=lb://servicio-nomina
-spring.cloud.gateway.routes[20].predicates[0]=Path=/api/conceptos/**
-spring.cloud.gateway.routes[20].predicates[1]=Method=POST
-spring.cloud.gateway.routes[20].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[20].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[20].id=concepto-write
+spring.cloud.gateway.server.webflux.routes[20].uri=lb://servicio-nomina
+spring.cloud.gateway.server.webflux.routes[20].predicates[0]=Path=/api/conceptos/**
+spring.cloud.gateway.server.webflux.routes[20].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[20].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[20].predicates[3]=Method=DELETE
 
-spring.cloud.gateway.routes[21].id=concepto-read
-spring.cloud.gateway.routes[21].uri=lb://servicio-consultas
-spring.cloud.gateway.routes[21].predicates[0]=Path=/api/conceptos/**
-spring.cloud.gateway.routes[21].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[21].id=concepto-read
+spring.cloud.gateway.server.webflux.routes[21].uri=lb://servicio-consultas
+spring.cloud.gateway.server.webflux.routes[21].predicates[0]=Path=/api/conceptos/**
+spring.cloud.gateway.server.webflux.routes[21].predicates[1]=Method=GET
 
 # Ruta adicional para asignar un concepto a un empleado
-spring.cloud.gateway.routes[24].id=empleado-concepto-write
-spring.cloud.gateway.routes[24].uri=lb://servicio-nomina
-spring.cloud.gateway.routes[24].predicates[0]=Path=/api/empleados/{id}/conceptos/**
-spring.cloud.gateway.routes[24].predicates[1]=Method=POST
-spring.cloud.gateway.routes[24].order=-1
+spring.cloud.gateway.server.webflux.routes[24].id=empleado-concepto-write
+spring.cloud.gateway.server.webflux.routes[24].uri=lb://servicio-nomina
+spring.cloud.gateway.server.webflux.routes[24].predicates[0]=Path=/api/empleados/{id}/conceptos/**
+spring.cloud.gateway.server.webflux.routes[24].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[24].order=-1
 
 # ========================================
 # Rutas de SAGA (todas en el path /api/saga/)
 # ========================================
 
 # 11. Escritura SAGA (alta/actualización flujo SAGA)
-spring.cloud.gateway.routes[22].id=saga-write
-spring.cloud.gateway.routes[22].uri=lb://servicio-orquestador
-spring.cloud.gateway.routes[22].predicates[0]=Path=/api/saga/**
-spring.cloud.gateway.routes[22].predicates[1]=Method=POST
-spring.cloud.gateway.routes[22].predicates[2]=Method=PUT
-spring.cloud.gateway.routes[22].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[22].id=saga-write
+spring.cloud.gateway.server.webflux.routes[22].uri=lb://servicio-orquestador
+spring.cloud.gateway.server.webflux.routes[22].predicates[0]=Path=/api/saga/**
+spring.cloud.gateway.server.webflux.routes[22].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[22].predicates[2]=Method=PUT
+spring.cloud.gateway.server.webflux.routes[22].predicates[3]=Method=DELETE
 
 # 12. Lectura SAGA (estado, consultas)
-spring.cloud.gateway.routes[23].id=saga-read
-spring.cloud.gateway.routes[23].uri=lb://servicio-orquestador
-spring.cloud.gateway.routes[23].predicates[0]=Path=/api/saga/**
-spring.cloud.gateway.routes[23].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[23].id=saga-read
+spring.cloud.gateway.server.webflux.routes[23].uri=lb://servicio-orquestador
+spring.cloud.gateway.server.webflux.routes[23].predicates[0]=Path=/api/saga/**
+spring.cloud.gateway.server.webflux.routes[23].predicates[1]=Method=GET
 
 # 13. Circuit Breaker status endpoints expuestos por el orquestador
-spring.cloud.gateway.routes[25].id=orquestador-cbstate
-spring.cloud.gateway.routes[25].uri=lb://servicio-orquestador
-spring.cloud.gateway.routes[25].predicates[0]=Path=/actuator/cb-state/**
-spring.cloud.gateway.routes[25].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[25].id=orquestador-cbstate
+spring.cloud.gateway.server.webflux.routes[25].uri=lb://servicio-orquestador
+spring.cloud.gateway.server.webflux.routes[25].predicates[0]=Path=/actuator/cb-state/**
+spring.cloud.gateway.server.webflux.routes[25].predicates[1]=Method=GET
 
 
 logging.level.org.springframework.cloud.gateway.discovery=DEBUG


### PR DESCRIPTION
## Summary
- restore the `spring.cloud.gateway.server.webflux` prefix in application properties so Spring Cloud Gateway can load its routes

## Testing
- `mvn -q -pl API-gateway test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb045eb0832490e5b1b25eb8c8e7