### PR TITLE
Fix property binding for gateway

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -34,151 +34,219 @@ spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed
 # 0. Empleado
 spring.cloud.gateway.server.webflux.routes[0].id=empleado-write
 spring.cloud.gateway.server.webflux.routes[0].uri=lb://servicio-empleado
-spring.cloud.gateway.server.webflux.routes[0].predicates[0]=Path=/api/empleados/**
-spring.cloud.gateway.server.webflux.routes[0].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[0].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[0].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[0].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[0].predicates[0].args[pattern]=/api/empleados/**
+spring.cloud.gateway.server.webflux.routes[0].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[0].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[0].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[0].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[0].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[0].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[1].id=empleado-read
 spring.cloud.gateway.server.webflux.routes[1].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[1].predicates[0]=Path=/api/empleados/**
-spring.cloud.gateway.server.webflux.routes[1].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[1].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[1].predicates[0].args[pattern]=/api/empleados/**
+spring.cloud.gateway.server.webflux.routes[1].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[1].predicates[1].args[methods]=GET
 
 # 1. Contrato
 spring.cloud.gateway.server.webflux.routes[2].id=contrato-write
 spring.cloud.gateway.server.webflux.routes[2].uri=lb://servicio-contrato
-spring.cloud.gateway.server.webflux.routes[2].predicates[0]=Path=/api/contratos/**
-spring.cloud.gateway.server.webflux.routes[2].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[2].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[2].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[2].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[2].predicates[0].args[pattern]=/api/contratos/**
+spring.cloud.gateway.server.webflux.routes[2].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[2].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[2].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[2].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[2].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[2].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[3].id=contrato-read
 spring.cloud.gateway.server.webflux.routes[3].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[3].predicates[0]=Path=/api/contratos/**
-spring.cloud.gateway.server.webflux.routes[3].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[3].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[3].predicates[0].args[pattern]=/api/contratos/**
+spring.cloud.gateway.server.webflux.routes[3].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[3].predicates[1].args[methods]=GET
 
 # 2. Jornada
 spring.cloud.gateway.server.webflux.routes[4].id=jornada-write
 spring.cloud.gateway.server.webflux.routes[4].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.server.webflux.routes[4].predicates[0]=Path=/api/jornadas/**
-spring.cloud.gateway.server.webflux.routes[4].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[4].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[4].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[4].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[4].predicates[0].args[pattern]=/api/jornadas/**
+spring.cloud.gateway.server.webflux.routes[4].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[4].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[4].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[4].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[4].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[4].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[5].id=jornada-read
 spring.cloud.gateway.server.webflux.routes[5].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[5].predicates[0]=Path=/api/jornadas/**
-spring.cloud.gateway.server.webflux.routes[5].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[5].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[5].predicates[0].args[pattern]=/api/jornadas/**
+spring.cloud.gateway.server.webflux.routes[5].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[5].predicates[1].args[methods]=GET
 
 # 3. Turno
 spring.cloud.gateway.server.webflux.routes[6].id=turno-write
 spring.cloud.gateway.server.webflux.routes[6].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.server.webflux.routes[6].predicates[0]=Path=/api/turnos/**
-spring.cloud.gateway.server.webflux.routes[6].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[6].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[6].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[6].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[6].predicates[0].args[pattern]=/api/turnos/**
+spring.cloud.gateway.server.webflux.routes[6].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[6].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[6].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[6].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[6].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[6].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[7].id=turno-read
 spring.cloud.gateway.server.webflux.routes[7].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[7].predicates[0]=Path=/api/turnos/**
-spring.cloud.gateway.server.webflux.routes[7].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[7].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[7].predicates[0].args[pattern]=/api/turnos/**
+spring.cloud.gateway.server.webflux.routes[7].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[7].predicates[1].args[methods]=GET
 
 # 4. Asistencia
 spring.cloud.gateway.server.webflux.routes[8].id=asistencia-write
 spring.cloud.gateway.server.webflux.routes[8].uri=lb://servicio-contrato
-spring.cloud.gateway.server.webflux.routes[8].predicates[0]=Path=/api/asistencias/**
-spring.cloud.gateway.server.webflux.routes[8].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[8].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[8].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[8].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[8].predicates[0].args[pattern]=/api/asistencias/**
+spring.cloud.gateway.server.webflux.routes[8].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[8].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[8].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[8].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[8].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[8].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[9].id=asistencia-read
 spring.cloud.gateway.server.webflux.routes[9].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[9].predicates[0]=Path=/api/asistencias/**
-spring.cloud.gateway.server.webflux.routes[9].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[9].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[9].predicates[0].args[pattern]=/api/asistencias/**
+spring.cloud.gateway.server.webflux.routes[9].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[9].predicates[1].args[methods]=GET
 
 # 5. Licencia
 spring.cloud.gateway.server.webflux.routes[10].id=licencia-write
 spring.cloud.gateway.server.webflux.routes[10].uri=lb://servicio-contrato
-spring.cloud.gateway.server.webflux.routes[10].predicates[0]=Path=/api/licencias/**
-spring.cloud.gateway.server.webflux.routes[10].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[10].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[10].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[10].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[10].predicates[0].args[pattern]=/api/licencias/**
+spring.cloud.gateway.server.webflux.routes[10].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[10].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[10].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[10].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[10].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[10].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[11].id=licencia-read
 spring.cloud.gateway.server.webflux.routes[11].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[11].predicates[0]=Path=/api/licencias/**
-spring.cloud.gateway.server.webflux.routes[11].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[11].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[11].predicates[0].args[pattern]=/api/licencias/**
+spring.cloud.gateway.server.webflux.routes[11].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[11].predicates[1].args[methods]=GET
 
 # 6. Vacación
 spring.cloud.gateway.server.webflux.routes[12].id=vacacion-write
 spring.cloud.gateway.server.webflux.routes[12].uri=lb://servicio-contrato
-spring.cloud.gateway.server.webflux.routes[12].predicates[0]=Path=/api/vacaciones/**
-spring.cloud.gateway.server.webflux.routes[12].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[12].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[12].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[12].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[12].predicates[0].args[pattern]=/api/vacaciones/**
+spring.cloud.gateway.server.webflux.routes[12].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[12].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[12].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[12].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[12].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[12].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[13].id=vacacion-read
 spring.cloud.gateway.server.webflux.routes[13].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[13].predicates[0]=Path=/api/vacaciones/**
-spring.cloud.gateway.server.webflux.routes[13].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[13].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[13].predicates[0].args[pattern]=/api/vacaciones/**
+spring.cloud.gateway.server.webflux.routes[13].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[13].predicates[1].args[methods]=GET
 
 # 7. Capacitación
 spring.cloud.gateway.server.webflux.routes[14].id=capacitacion-write
 spring.cloud.gateway.server.webflux.routes[14].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.server.webflux.routes[14].predicates[0]=Path=/api/capacitaciones/**
-spring.cloud.gateway.server.webflux.routes[14].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[14].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[14].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[14].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[14].predicates[0].args[pattern]=/api/capacitaciones/**
+spring.cloud.gateway.server.webflux.routes[14].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[14].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[14].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[14].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[14].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[14].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[15].id=capacitacion-read
 spring.cloud.gateway.server.webflux.routes[15].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[15].predicates[0]=Path=/api/capacitaciones/**
-spring.cloud.gateway.server.webflux.routes[15].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[15].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[15].predicates[0].args[pattern]=/api/capacitaciones/**
+spring.cloud.gateway.server.webflux.routes[15].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[15].predicates[1].args[methods]=GET
 
 # 8. Evaluación
 spring.cloud.gateway.server.webflux.routes[16].id=evaluacion-write
 spring.cloud.gateway.server.webflux.routes[16].uri=lb://servicio-entrenamiento
-spring.cloud.gateway.server.webflux.routes[16].predicates[0]=Path=/api/evaluaciones/**
-spring.cloud.gateway.server.webflux.routes[16].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[16].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[16].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[16].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[16].predicates[0].args[pattern]=/api/evaluaciones/**
+spring.cloud.gateway.server.webflux.routes[16].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[16].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[16].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[16].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[16].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[16].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[17].id=evaluacion-read
 spring.cloud.gateway.server.webflux.routes[17].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[17].predicates[0]=Path=/api/evaluaciones/**
-spring.cloud.gateway.server.webflux.routes[17].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[17].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[17].predicates[0].args[pattern]=/api/evaluaciones/**
+spring.cloud.gateway.server.webflux.routes[17].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[17].predicates[1].args[methods]=GET
 
 # 9. Liquidación
 spring.cloud.gateway.server.webflux.routes[18].id=liquidacion-write
 spring.cloud.gateway.server.webflux.routes[18].uri=lb://servicio-nomina
-spring.cloud.gateway.server.webflux.routes[18].predicates[0]=Path=/api/liquidaciones/**
-spring.cloud.gateway.server.webflux.routes[18].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[18].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[18].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[18].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[18].predicates[0].args[pattern]=/api/liquidaciones/**
+spring.cloud.gateway.server.webflux.routes[18].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[18].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[18].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[18].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[18].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[18].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[19].id=liquidacion-read
 spring.cloud.gateway.server.webflux.routes[19].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[19].predicates[0]=Path=/api/liquidaciones/**
-spring.cloud.gateway.server.webflux.routes[19].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[19].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[19].predicates[0].args[pattern]=/api/liquidaciones/**
+spring.cloud.gateway.server.webflux.routes[19].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[19].predicates[1].args[methods]=GET
 
 # 10. Concepto de Liquidación
 spring.cloud.gateway.server.webflux.routes[20].id=concepto-write
 spring.cloud.gateway.server.webflux.routes[20].uri=lb://servicio-nomina
-spring.cloud.gateway.server.webflux.routes[20].predicates[0]=Path=/api/conceptos/**
-spring.cloud.gateway.server.webflux.routes[20].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[20].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[20].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[20].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[20].predicates[0].args[pattern]=/api/conceptos/**
+spring.cloud.gateway.server.webflux.routes[20].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[20].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[20].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[20].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[20].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[20].predicates[3].args[methods]=DELETE
 
 spring.cloud.gateway.server.webflux.routes[21].id=concepto-read
 spring.cloud.gateway.server.webflux.routes[21].uri=lb://servicio-consultas
-spring.cloud.gateway.server.webflux.routes[21].predicates[0]=Path=/api/conceptos/**
-spring.cloud.gateway.server.webflux.routes[21].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[21].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[21].predicates[0].args[pattern]=/api/conceptos/**
+spring.cloud.gateway.server.webflux.routes[21].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[21].predicates[1].args[methods]=GET
 
 # Ruta adicional para asignar un concepto a un empleado
 spring.cloud.gateway.server.webflux.routes[24].id=empleado-concepto-write
 spring.cloud.gateway.server.webflux.routes[24].uri=lb://servicio-nomina
-spring.cloud.gateway.server.webflux.routes[24].predicates[0]=Path=/api/empleados/{id}/conceptos/**
-spring.cloud.gateway.server.webflux.routes[24].predicates[1]=Method=POST
+spring.cloud.gateway.server.webflux.routes[24].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[24].predicates[0].args[pattern]=/api/empleados/{id}/conceptos/**
+spring.cloud.gateway.server.webflux.routes[24].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[24].predicates[1].args[methods]=POST
 spring.cloud.gateway.server.webflux.routes[24].order=-1
 
 # ========================================
@@ -188,22 +256,30 @@ spring.cloud.gateway.server.webflux.routes[24].order=-1
 # 11. Escritura SAGA (alta/actualización flujo SAGA)
 spring.cloud.gateway.server.webflux.routes[22].id=saga-write
 spring.cloud.gateway.server.webflux.routes[22].uri=lb://servicio-orquestador
-spring.cloud.gateway.server.webflux.routes[22].predicates[0]=Path=/api/saga/**
-spring.cloud.gateway.server.webflux.routes[22].predicates[1]=Method=POST
-spring.cloud.gateway.server.webflux.routes[22].predicates[2]=Method=PUT
-spring.cloud.gateway.server.webflux.routes[22].predicates[3]=Method=DELETE
+spring.cloud.gateway.server.webflux.routes[22].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[22].predicates[0].args[pattern]=/api/saga/**
+spring.cloud.gateway.server.webflux.routes[22].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[22].predicates[1].args[methods]=POST
+spring.cloud.gateway.server.webflux.routes[22].predicates[2].name=Method
+spring.cloud.gateway.server.webflux.routes[22].predicates[2].args[methods]=PUT
+spring.cloud.gateway.server.webflux.routes[22].predicates[3].name=Method
+spring.cloud.gateway.server.webflux.routes[22].predicates[3].args[methods]=DELETE
 
 # 12. Lectura SAGA (estado, consultas)
 spring.cloud.gateway.server.webflux.routes[23].id=saga-read
 spring.cloud.gateway.server.webflux.routes[23].uri=lb://servicio-orquestador
-spring.cloud.gateway.server.webflux.routes[23].predicates[0]=Path=/api/saga/**
-spring.cloud.gateway.server.webflux.routes[23].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[23].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[23].predicates[0].args[pattern]=/api/saga/**
+spring.cloud.gateway.server.webflux.routes[23].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[23].predicates[1].args[methods]=GET
 
 # 13. Circuit Breaker status endpoints expuestos por el orquestador
 spring.cloud.gateway.server.webflux.routes[25].id=orquestador-cbstate
 spring.cloud.gateway.server.webflux.routes[25].uri=lb://servicio-orquestador
-spring.cloud.gateway.server.webflux.routes[25].predicates[0]=Path=/actuator/cb-state/**
-spring.cloud.gateway.server.webflux.routes[25].predicates[1]=Method=GET
+spring.cloud.gateway.server.webflux.routes[25].predicates[0].name=Path
+spring.cloud.gateway.server.webflux.routes[25].predicates[0].args[pattern]=/actuator/cb-state/**
+spring.cloud.gateway.server.webflux.routes[25].predicates[1].name=Method
+spring.cloud.gateway.server.webflux.routes[25].predicates[1].args[methods]=GET
 
 
 logging.level.org.springframework.cloud.gateway.discovery=DEBUG


### PR DESCRIPTION
## Summary
- update `application.properties` in API-gateway to use new structured `name` and `args` keys for predicates

## Testing
- `mvn` command not found

------
https://chatgpt.com/codex/tasks/task_e_6866ec40dbf483249a18f964f84f253a