### PR TITLE
Agregar microservicio de interfaz de usuario OpenAPI

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,7 @@ Los módulos disponibles son (cada uno incluye su propio `README.adoc`):
 * link:servicio-consultas/README.adoc[servicio-consultas]
 * link:API-gateway/README.adoc[API-gateway]
 * link:servidor-para-descubrimiento/README.adoc[servidor-para-descubrimiento]
+* link:servicio-openapi-ui/README.adoc[servicio-openapi-ui]
 Para compilar o ejecutar el conjunto completo con `mvn install` conviene iniciar primero este módulo desde otra terminal:
 
 [source,bash]

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>servicio-orquestador</module>
         <module>servicio-consultas</module>
         <module>API-gateway</module>
+        <module>servicio-openapi-ui</module>
     </modules>
 
     <properties>

--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -1,0 +1,13 @@
+= Servicio OpenAPI UI
+
+Interfaz web simple que muestra la documentación OpenAPI del API Gateway usando ReDoc.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más detalles.
+
+== Uso
+
+Levantá el servicio y accedé a `http://localhost:8085` para visualizar la documentación.
+
+== Documentación OpenAPI
+
+Este módulo no expone controladores propios; carga el archivo generado por el API Gateway en `/v3/api-docs`.

--- a/servicio-openapi-ui/pom.xml
+++ b/servicio-openapi-ui/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ar.org.hospitalcuencaalta</groupId>
+        <artifactId>rrhh</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>servicio-openapi-ui</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>servicio-openapi-ui</name>
+    <description>Interfaz para visualizar la documentación OpenAPI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/servicio-openapi-ui/src/main/java/ar/org/hospitalcuencaalta/servicio_openapi_ui/ServicioOpenapiUiApplication.java
+++ b/servicio-openapi-ui/src/main/java/ar/org/hospitalcuencaalta/servicio_openapi_ui/ServicioOpenapiUiApplication.java
@@ -1,0 +1,11 @@
+package ar.org.hospitalcuencaalta.servicio_openapi_ui;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ServicioOpenapiUiApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ServicioOpenapiUiApplication.class, args);
+    }
+}

--- a/servicio-openapi-ui/src/main/resources/application.properties
+++ b/servicio-openapi-ui/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.application.name=servicio-openapi-ui
+server.port=8085
+
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka
+eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OpenAPI UI</title>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+</head>
+<body>
+<redoc spec-url="http://localhost:8080/v3/api-docs"></redoc>
+</body>
+</html>

--- a/servicio-openapi-ui/src/test/java/ar/org/hospitalcuencaalta/servicio_openapi_ui/ServicioOpenapiUiApplicationTests.java
+++ b/servicio-openapi-ui/src/test/java/ar/org/hospitalcuencaalta/servicio_openapi_ui/ServicioOpenapiUiApplicationTests.java
@@ -1,0 +1,11 @@
+package ar.org.hospitalcuencaalta.servicio_openapi_ui;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ServicioOpenapiUiApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add new `servicio-openapi-ui` module
- include ReDoc page for viewing API Gateway docs
- register new module in parent pom and README

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_68676701ccdc8324af6bde8d590174c4