### PR TITLE
Fix WebConfig build by adding missing web dependency

### DIFF
--- a/comunes/pom.xml
+++ b/comunes/pom.xml
@@ -27,6 +27,11 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+        <!-- Basic web dependencies required for WebConfig -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.statemachine</groupId>
             <artifactId>spring-statemachine-core</artifactId>


### PR DESCRIPTION
## Summary
- add `spring-boot-starter-web` to the `comunes` module so that `WebConfig` compiles

## Testing
- `mvn test -pl comunes` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867d051650c8324bc1487d86a04bf96