### PR TITLE
Fix CompensacionSagaActions Kafka bean

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/KafkaTemplateConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/KafkaTemplateConfig.java
@@ -1,0 +1,18 @@
+package ar.org.hospitalcuencaalta.servicio_orquestador.config;
+
+import ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.CompensacionDto;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaTemplateConfig {
+
+    @Bean
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public KafkaTemplate<String, CompensacionDto> compensacionKafkaTemplate(
+            ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate(producerFactory);
+    }
+}


### PR DESCRIPTION
## Summary
- provide `KafkaTemplate<String, CompensacionDto>` bean so the state machine actions can publish events

## Testing
- `./mvnw -q -pl servicio-orquestador test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6867da0a898c8324b9db75eb5af704d2