### PR TITLE
Fix CORS headers on API gateway

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -22,9 +22,9 @@ spring.cloud.gateway.server.webflux.discovery.locator.lower-case-service-id=true
 eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}
 
 # CORS Global
-spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-origins=*
-spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
-spring.cloud.gateway.server.webflux.globalcors.cors-configurations.[/**].allowed-headers=*
+spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowed-origins=*
+spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
+spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowed-headers=*
 
 # =============================================================
 # Routes: Escritura (POST, PUT, DELETE) → servicios del dominio


### PR DESCRIPTION
## Summary
- fix incorrect property names for CORS on API gateway

## Testing
- `./mvnw -q -pl API-gateway test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6867e8411d04832484d380d3d2c80c4c