### PR TITLE
Corregir el CORS de la puerta de enlace para solicitudes OpenAPI

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -25,6 +25,7 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowed-origins=*
 spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowed-methods=GET,POST,PUT,DELETE,OPTIONS
 spring.cloud.gateway.globalcors.corsConfigurations.[/**].allowed-headers=*
+spring.cloud.gateway.globalcors.add-to-simple-url-handler-mapping=true
 
 # =============================================================
 # Routes: Escritura (POST, PUT, DELETE) → servicios del dominio


### PR DESCRIPTION
## Summary
- enable global CORS mapping for resources handled by `SimpleUrlHandlerMapping`

## Testing
- `./mvnw -q -pl API-gateway test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9ab07d8832486a8446a48bbc189