### PR TITLE
Corregir CORS para la documentación de la API

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/CorsFilterConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/CorsFilterConfig.java
@@ -1,0 +1,22 @@
+package ar.org.hospitalcuencaalta.api_gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsFilterConfig {
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsWebFilter(source);
+    }
+}


### PR DESCRIPTION
## Summary
- add reactive `CorsWebFilter` to API Gateway so `/v3/api-docs` can be fetched from other ports

## Testing
- `./mvnw -q test` *(fails: Could not download maven)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb1367ec8324818c779fa896fcff