### PR TITLE
Fix springdoc scanning across services

### DIFF
--- a/servicio-consultas/src/main/resources/application.properties
+++ b/servicio-consultas/src/main/resources/application.properties
@@ -32,3 +32,6 @@ spring.kafka.consumer.properties.spring.json.type.mapping=ar.org.hospitalcuencaa
 # topic de compensación SAGA
 spring.kafka.topic.saga.compensated=saga.compensated
 
+
+# SpringDoc configuration
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_consultas.controlador

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -33,3 +33,6 @@ spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.sp
 spring.kafka.consumer.properties.spring.json.trusted.packages=*
 spring.kafka.consumer.properties.spring.json.use.type.headers=true
 spring.kafka.consumer.properties.spring.json.type.mapping=ar.org.hospitalcuencaalta.comunes.dto.EmpleadoEventDto:ar.org.hospitalcuencaalta.servicio_contrato.web.dto.EmpleadoRegistryDto
+
+# SpringDoc configuration
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_contrato.controlador

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -56,5 +56,7 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 spring.kafka.producer.properties.spring.json.add.type.headers=true
 
 # SpringDoc configuration
-# Use default scanning across the service packages
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_empleado.controlador
+
+# Use default OpenAPI groups and paths
 

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -40,3 +40,6 @@ ar.org.hospitalcuencaalta.servicio_orquestador.web.dto.EmpleadoDto:ar.org.hospit
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 spring.kafka.producer.properties.spring.json.add.type.headers=true
+
+# SpringDoc configuration
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_entrenamiento.controlador

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -45,3 +45,5 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 # Include exception messages in error responses
 server.error.include-message=always
 
+# SpringDoc configuration
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_nomina.controlador

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -157,3 +157,6 @@ logging.level.org.apache.kafka=INFO
 ############################################################
 #spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 spring.main.allow-bean-definition-overriding=true
+
+# SpringDoc configuration
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_orquestador.controlador


### PR DESCRIPTION
## Summary
- restrict the SpringDoc scan packages across microservices so each service generates its OpenAPI spec reliably

## Testing
- `grep -n "springdoc.packages-to-scan" servicio-consultas/src/main/resources/application.properties`
- `grep -n "springdoc.packages-to-scan" servicio-contrato/src/main/resources/application.properties`
- `grep -n "springdoc.packages-to-scan" servicio-entrenamiento/src/main/resources/application.properties`
- `grep -n "springdoc.packages-to-scan" servicio-nomina/src/main/resources/application.properties`
- `grep -n "springdoc.packages-to-scan" servicio-orquestador/src/main/resources/application.properties`


------
https://chatgpt.com/codex/tasks/task_e_6867ec94ae188324ab3d971cdc90eac1