### PR TITLE
Fix docs retrieval via gateway

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -89,7 +89,9 @@ Asegurate de que tu instancia local de MariaDB esté corriendo con esas bases de
 == Documentación OpenAPI
 
 Cada microservicio expone su especificación OpenAPI en `/v3/api-docs` y una
-interfaz Swagger UI en `/swagger-ui.html`. Estas URLs estarán disponibles en los
+interfaz Swagger UI en `/swagger-ui.html`. Cuando se ejecutan detrás del API Gateway,
+podés acceder a cada una de ellas a través de rutas como
+`http://localhost:8080/<servicio>/v3/api-docs`. Estas URLs estarán disponibles en los
 entornos de desarrollo y podrán restringirse cuando se agregue seguridad.
 
 == Postman Tests

--- a/docs/postman/openapi-tests.postman_collection.json
+++ b/docs/postman/openapi-tests.postman_collection.json
@@ -31,7 +31,7 @@
       "name": "Empleado docs",
       "request": {
         "method": "GET",
-        "url": "{{empleadoUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servicio-empleado/v3/api-docs"
       },
       "event": [
         {
@@ -54,7 +54,7 @@
       "name": "Contrato docs",
       "request": {
         "method": "GET",
-        "url": "{{contratoUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servicio-contrato/v3/api-docs"
       },
       "event": [
         {
@@ -77,7 +77,7 @@
       "name": "Entrenamiento docs",
       "request": {
         "method": "GET",
-        "url": "{{entrenamientoUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servicio-entrenamiento/v3/api-docs"
       },
       "event": [
         {
@@ -100,7 +100,7 @@
       "name": "Nomina docs",
       "request": {
         "method": "GET",
-        "url": "{{nominaUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servicio-nomina/v3/api-docs"
       },
       "event": [
         {
@@ -123,7 +123,7 @@
       "name": "Consultas docs",
       "request": {
         "method": "GET",
-        "url": "{{consultasUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servicio-consultas/v3/api-docs"
       },
       "event": [
         {
@@ -146,7 +146,7 @@
       "name": "Orquestador docs",
       "request": {
         "method": "GET",
-        "url": "{{orquestadorUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servicio-orquestador/v3/api-docs"
       },
       "event": [
         {
@@ -169,7 +169,7 @@
       "name": "Eureka docs",
       "request": {
         "method": "GET",
-        "url": "{{eurekaUrl}}/v3/api-docs"
+        "url": "{{gatewayUrl}}/servidor-para-descubrimiento/v3/api-docs"
       },
       "event": [
         {
@@ -193,34 +193,6 @@
     {
       "key": "gatewayUrl",
       "value": "http://localhost:8080"
-    },
-    {
-      "key": "empleadoUrl",
-      "value": "http://localhost:8081"
-    },
-    {
-      "key": "contratoUrl",
-      "value": "http://localhost:8082"
-    },
-    {
-      "key": "entrenamientoUrl",
-      "value": "http://localhost:8083"
-    },
-    {
-      "key": "nominaUrl",
-      "value": "http://localhost:8084"
-    },
-    {
-      "key": "consultasUrl",
-      "value": "http://localhost:8090"
-    },
-    {
-      "key": "orquestadorUrl",
-      "value": "http://localhost:8095"
-    },
-    {
-      "key": "eurekaUrl",
-      "value": "http://localhost:8761"
     }
   ]
 }

--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -11,5 +11,6 @@ Seleccioná el microservicio deseado en el menú desplegable para visualizar su 
 
 == Documentación OpenAPI
 
-Este módulo no expone controladores propios. Carga los archivos generados por cada servicio
-(`http://localhost:<puerto>/v3/api-docs`) y permite alternar entre ellos desde la interfaz.
+Este módulo no expone controladores propios. Obtiene las especificaciones a través del API Gateway
+usando rutas como `http://localhost:8080/<servicio>/v3/api-docs`, lo que permite resolver los
+destinos dinámicamente mediante Eureka y balanceo de carga.

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -19,13 +19,13 @@
     <label for="service-select">Servicio:</label>
     <select id="service-select">
       <option value="http://localhost:8080/v3/api-docs">API Gateway</option>
-      <option value="http://localhost:8081/v3/api-docs">servicio-empleado</option>
-      <option value="http://localhost:8082/v3/api-docs">servicio-contrato</option>
-      <option value="http://localhost:8083/v3/api-docs">servicio-entrenamiento</option>
-      <option value="http://localhost:8084/v3/api-docs">servicio-nomina</option>
-      <option value="http://localhost:8090/v3/api-docs">servicio-consultas</option>
-      <option value="http://localhost:8095/v3/api-docs">servicio-orquestador</option>
-      <option value="http://localhost:8761/v3/api-docs">servidor-para-descubrimiento</option>
+      <option value="http://localhost:8080/servicio-empleado/v3/api-docs">servicio-empleado</option>
+      <option value="http://localhost:8080/servicio-contrato/v3/api-docs">servicio-contrato</option>
+      <option value="http://localhost:8080/servicio-entrenamiento/v3/api-docs">servicio-entrenamiento</option>
+      <option value="http://localhost:8080/servicio-nomina/v3/api-docs">servicio-nomina</option>
+      <option value="http://localhost:8080/servicio-consultas/v3/api-docs">servicio-consultas</option>
+      <option value="http://localhost:8080/servicio-orquestador/v3/api-docs">servicio-orquestador</option>
+      <option value="http://localhost:8080/servidor-para-descubrimiento/v3/api-docs">servidor-para-descubrimiento</option>
     </select>
   </div>
   <div id="redoc-container"></div>


### PR DESCRIPTION
## Summary
- update OpenAPI UI to use API gateway paths
- adjust README docs to reference gateway routes
- update Postman examples to hit gateway

## Testing
- `./mvnw -q test -pl servicio-openapi-ui` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_6867f51008c88324b0e16a9b407fd249