### PR TITLE
Corregir CORS y la propiedad springdoc

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
@@ -25,6 +25,8 @@ public class GatewayConfig {
                         .uri("lb://servicio-consultas"))
                 .route("saga_route", r -> r.path("/api/saga/**")
                         .uri("lb://servicio-orquestador"))
+                .route("discovery_route", r -> r.path("/servidor-para-descubrimiento/**")
+                        .uri("http://localhost:8761"))
                 .build();
     }
 }

--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayCorsConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayCorsConfig.java
@@ -1,0 +1,23 @@
+package ar.org.hospitalcuencaalta.api_gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+
+@Configuration
+public class GatewayCorsConfig {
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsWebFilter(source);
+    }
+}

--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -284,5 +284,5 @@ logging.level.com.netflix.discovery=INFO
 
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.api_gateway
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.api_gateway
 

--- a/servicio-consultas/src/main/resources/application.properties
+++ b/servicio-consultas/src/main/resources/application.properties
@@ -34,4 +34,4 @@ spring.kafka.topic.saga.compensated=saga.compensated
 
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.servicio_consultas.controlador
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_consultas.controlador

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -35,4 +35,4 @@ spring.kafka.consumer.properties.spring.json.use.type.headers=true
 spring.kafka.consumer.properties.spring.json.type.mapping=ar.org.hospitalcuencaalta.comunes.dto.EmpleadoEventDto:ar.org.hospitalcuencaalta.servicio_contrato.web.dto.EmpleadoRegistryDto
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.servicio_contrato.controlador
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_contrato.controlador

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -56,7 +56,7 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 spring.kafka.producer.properties.spring.json.add.type.headers=true
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.servicio_empleado.controlador
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_empleado.controlador
 
 # Use default OpenAPI groups and paths
 

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -42,4 +42,4 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 spring.kafka.producer.properties.spring.json.add.type.headers=true
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.servicio_entrenamiento.controlador
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_entrenamiento.controlador

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -46,4 +46,4 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 server.error.include-message=always
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.servicio_nomina.controlador
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_nomina.controlador

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -159,4 +159,4 @@ logging.level.org.apache.kafka=INFO
 spring.main.allow-bean-definition-overriding=true
 
 # SpringDoc configuration
-springdoc.packagesToScan=ar.org.hospitalcuencaalta.servicio_orquestador.controlador
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_orquestador.controlador


### PR DESCRIPTION
## Summary
- allow CORS in API gateway with a WebFlux filter
- proxy discovery server docs through gateway
- update springdoc property names across services

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_68680212bf908324872d17f5c720ebe5