### PR TITLE
Disable CORS headers in microservices

### DIFF
--- a/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/config/web/WebConfig.java
+++ b/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/config/web/WebConfig.java
@@ -16,10 +16,10 @@ public class WebConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("*")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*");
+                // Let the API gateway handle CORS headers to avoid duplicating
+                // Access-Control-Allow-* responses which caused browsers to
+                // reject requests. Leaving the mapping empty disables automatic
+                // header generation in the underlying microservices.
             }
         };
     }


### PR DESCRIPTION
## Summary
- prevent duplicate `Access-Control-Allow-*` headers generated from each service

## Testing
- `./mvnw -version` *(fails: NullPointerException)*

------
https://chatgpt.com/codex/tasks/task_e_686b916ee92c83249bff00a0f355ecb9