### PR TITLE
Mejorar la resiliencia de la interfaz de usuario de OpenAPI

### DIFF
--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -9,6 +9,9 @@ Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` p
 Levantá el servicio y accedé a `http://localhost:8085`.
 Seleccioná el microservicio deseado en el menú desplegable para visualizar su documentación.
 
+Todos los microservicios deben estar en ejecución para que sus especificaciones
+estén disponibles. De lo contrario, el visor mostrará un mensaje de error.
+
 == Documentación OpenAPI
 
 Este módulo no expone controladores propios. Obtiene las especificaciones a través del API Gateway

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -32,9 +32,15 @@
   <script>
     const container = document.getElementById('redoc-container');
     const select = document.getElementById('service-select');
+
     function loadSpec(url) {
-      Redoc.init(url, {}, container);
+      container.innerHTML = '';
+      Redoc.init(url, {}, container).catch(err => {
+        container.innerHTML = '<p>Error al cargar la documentación.</p>';
+        console.error('Error loading spec', err);
+      });
     }
+
     select.addEventListener('change', () => loadSpec(select.value));
     loadSpec(select.value);
   </script>


### PR DESCRIPTION
## Summary
- show clear error message when a specification fails to load
- document that each service must be running for the specs to be available

## Testing
- `./mvnw -pl servicio-openapi-ui test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686c160675088324af39282962c4e530