### PR TITLE
Corregir el error de recarga de Redoc

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -34,7 +34,6 @@
     const select = document.getElementById('service-select');
 
     function loadSpec(url) {
-      container.innerHTML = '';
       Redoc.init(url, {}, container).catch(err => {
         container.innerHTML = '<p>Error al cargar la documentación.</p>';
         console.error('Error loading spec', err);


### PR DESCRIPTION
## Summary
- fix Redoc reload when changing services in openapi ui

## Testing
- `./mvnw test -q` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686c8617b5c88324afe587ae62b5089b