### PR TITLE
Fix error loading OpenAPI spec in UI

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -34,10 +34,19 @@
     const select = document.getElementById('service-select');
 
     function loadSpec(url) {
-      Redoc.init(url, {}, container).catch(err => {
+      container.innerHTML = '';
+      try {
+        const result = Redoc.init(url, {}, container);
+        if (result && typeof result.catch === 'function') {
+          result.catch(err => {
+            container.innerHTML = '<p>Error al cargar la documentación.</p>';
+            console.error('Error loading spec', err);
+          });
+        }
+      } catch (err) {
         container.innerHTML = '<p>Error al cargar la documentación.</p>';
         console.error('Error loading spec', err);
-      });
+      }
     }
 
     select.addEventListener('change', () => loadSpec(select.value));


### PR DESCRIPTION
## Summary
- clear ReDoc container before loading new spec
- handle errors with try/catch so repeated loads don't crash

## Testing
- `./mvnw -q test -pl servicio-openapi-ui` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686c880a50a48324a2482b80e8fa62ff