### PR TITLE
Fix ReDoc reload error

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -30,11 +30,14 @@
   </div>
   <div id="redoc-container"></div>
   <script>
-    const container = document.getElementById('redoc-container');
+    let container = document.getElementById('redoc-container');
     const select = document.getElementById('service-select');
 
     function loadSpec(url) {
-      container.innerHTML = '';
+      const newContainer = document.createElement('div');
+      newContainer.id = 'redoc-container';
+      container.replaceWith(newContainer);
+      container = newContainer;
       try {
         const result = Redoc.init(url, {}, container);
         if (result && typeof result.catch === 'function') {


### PR DESCRIPTION
## Summary
- avoid DOM detach error when loading new OpenAPI docs by creating a fresh container each time

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686c89cec51c83249a737b8669d914fb