### PR TITLE
Habilitar OpenAPI para el servicio de descubrimiento

### DIFF
--- a/servidor-para-descubrimiento/src/main/java/ar/org/hospitalcuencaalta/servidor_para_descubrimiento/config/DiscoveryOpenApiConfig.java
+++ b/servidor-para-descubrimiento/src/main/java/ar/org/hospitalcuencaalta/servidor_para_descubrimiento/config/DiscoveryOpenApiConfig.java
@@ -1,0 +1,13 @@
+package ar.org.hospitalcuencaalta.servidor_para_descubrimiento.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Minimal OpenAPI configuration so the discovery server exposes an empty spec.
+ */
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "Discovery Server", version = "v1"))
+public class DiscoveryOpenApiConfig {
+}

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -16,3 +16,4 @@ eureka.client.fetch-registry=false
 # registrarse y buscar el registro de servicios
 eureka.client.service-url.defaultZone=http://${eureka.instance.hostname}:${server.port}/eureka/
 
+springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servidor_para_descubrimiento


### PR DESCRIPTION
## Summary
- add minimal OpenAPI config to discovery server
- enable SpringDoc scanning in discovery server

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686cd7be43c48324bf765a0a76c296e8