### PR TITLE
Agregar visor de docs AsciiDoc en OpenAPI UI

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/API-gateway_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/API-gateway_README.adoc
@@ -1,0 +1,61 @@
+= API Gateway
+
+Encamina las peticiones entrantes hacia los diferentes microservicios de RRHH.
+
+Forma parte del proyecto de microservicios. Consultá `../README.adoc` para detalles generales.
+
+Este servicio actúa como balanceador de carga utilizando Spring Cloud Gateway y Eureka. Todas las solicitudes pasan por aquí para enrutarse correctamente.
+
+== Rutas principales
+
+Las reglas de enrutamiento están definidas en `application.properties`. En general las operaciones de escritura (`POST`, `PUT`, `DELETE`) van al microservicio correspondiente y las consultas (`GET`) al `servicio-consultas`.
+
+* `/api/empleados/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-empleado`
+** `GET` -> `servicio-consultas`
+* `/api/contratos/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/jornadas/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/turnos/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/asistencias/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/licencias/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/vacaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/capacitaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/evaluaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/liquidaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-nomina`
+** `GET` -> `servicio-consultas`
+* `/api/conceptos/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-nomina`
+** `GET` -> `servicio-consultas`
+* `/api/empleados/{id}/conceptos/**`
+** `POST` -> `servicio-nomina`
+* `/api/saga/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-orquestador`
+** `GET` -> `servicio-orquestador`
+* `/actuator/cb-state/**`
+** `GET` -> `servicio-orquestador`
+
+== Comentarios
+
+El gateway se registra en Eureka y aplica balanceo de carga para cada ruta. Es el punto de entrada sugerido para integrar clientes externos. Los diagramas están en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Swagger UI está disponible en `/swagger-ui.html` y expone la descripción de las
+rutas en `/v3/api-docs`.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/comunes_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/comunes_README.adoc
@@ -1,0 +1,14 @@
+= Módulo Comunes
+
+Biblioteca con entidades y utilidades compartidas por los servicios de RRHH.
+
+Consultá `../README.adoc` para instrucciones generales de construcción y ejecución.
+
+== Contenido principal
+
+Incluye DTOs, mapeos y clases utilitarias utilizadas por los demás microservicios.
+
+== Comentarios
+
+No es un servicio independiente sino una dependencia común.
+Los diagramas que describen estas entidades están en `docs/uml/local`.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/root_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/root_README.adoc
@@ -1,0 +1,110 @@
+= Microservicios de RRHH
+
+Este repositorio contiene varios servicios de Spring Boot que conforman el sistema de recursos humanos.
+
+== Requisitos previos
+
+* Debés tener instalado JDK 17 y disponible en tu `PATH`.
+* MariaDB tiene que estar corriendo de forma local para los perfiles de desarrollo y producción. Creá las bases de datos llamadas `contrato`, `empleado`, `entrenamiento`, `nomina`, `consultas` y `orquestador`.
+* Docker y Docker Compose para la infraestructura opcional (Kafka y Zookeeper). Se provee un archivo `compose.yaml`.
+* Las pruebas usan la base H2 en memoria, así que no necesitás configuración adicional.
+
+== Compilación y ejecución de los servicios
+
+Cada módulo de servicio incluye su propio script de Maven Wrapper. Navegá al módulo deseado y ejecutá:
+
+[source,bash]
+----
+./mvnw spring-boot:run
+----
+
+Los módulos disponibles son (cada uno incluye su propio `README.adoc`):
+
+* link:comunes/README.adoc[comunes]
+* link:servicio-contrato/README.adoc[servicio-contrato]
+* link:servicio-empleado/README.adoc[servicio-empleado]
+* link:servicio-entrenamiento/README.adoc[servicio-entrenamiento]
+* link:servicio-nomina/README.adoc[servicio-nomina]
+* link:servicio-orquestador/README.adoc[servicio-orquestador]
+* link:servicio-consultas/README.adoc[servicio-consultas]
+* link:API-gateway/README.adoc[API-gateway]
+* link:servidor-para-descubrimiento/README.adoc[servidor-para-descubrimiento]
+* link:servicio-openapi-ui/README.adoc[servicio-openapi-ui]
+Para compilar o ejecutar el conjunto completo con `mvn install` conviene iniciar primero este módulo desde otra terminal:
+
+[source,bash]
+----
+./mvnw -pl servidor-para-descubrimiento spring-boot:run
+----
+De esta manera Eureka estará activo y el resto de los servicios podrán registrarse correctamente.
+El API Gateway se ejecuta por defecto en el puerto 8080 y distribuye las peticiones hacia los microservicios registrados en Eureka, permitiendo escalar cada servicio con múltiples instancias.
+
+Cada README local describe en detalle las acciones disponibles y muestra los diagramas PlantUML correspondientes.
+
+== Propiedades del proyecto
+
+El `pom.xml` principal define varias versiones compartidas para los módulos. Las
+más relevantes son:
+
+* `java.version` -> 17
+* `spring-cloud.version` -> 2025.0.0
+* `require.maven.version` -> 3.9.9
+* `actuator.version` -> 3.5.0
+
+Desde la raíz del repositorio podés compilar todos los módulos a la vez:
+
+[source,bash]
+----
+./mvnw clean package
+----
+
+== Ejecución de pruebas
+
+Ejecutá las pruebas de todos los módulos con:
+
+[source,bash]
+----
+./mvnw test
+----
+
+o dentro de un módulo en particular:
+
+[source,bash]
+----
+cd servicio-contrato
+./mvnw test
+----
+
+== Docker Compose
+
+Se incluye una configuración mínima de Docker Compose para levantar Kafka y Zookeeper que requieren los servicios:
+
+[source,bash]
+----
+docker compose up -d
+----
+
+Asegurate de que tu instancia local de MariaDB esté corriendo con esas bases de datos creadas antes de iniciar los servicios. Las pruebas usarán H2 automáticamente.
+
+== Documentación OpenAPI
+
+Cada microservicio expone su especificación OpenAPI en `/v3/api-docs` y una
+interfaz Swagger UI en `/swagger-ui.html`. Cuando se ejecutan detrás del API Gateway,
+podés acceder a cada una de ellas a través de rutas como
+`http://localhost:8080/<servicio>/v3/api-docs`. Estas URLs estarán disponibles en los
+entornos de desarrollo y podrán restringirse cuando se agregue seguridad.
+
+== Postman Tests
+
+En `docs/postman` se incluyen colecciones de Postman de ejemplo. Importá `rrhh-saga-tests.postman_collection.json` en Postman para probar los flujos de creación, actualización, eliminación y estado de la SAGA mediante los endpoints `/api/saga/empleado-contrato`. El archivo `consultas-saga-tests.postman_collection.json` contiene solicitudes adicionales que validan cómo `servicio-consultas` se actualiza luego de cada operación POST, PUT y DELETE. La respuesta del POST inicial guarda los identificadores de empleado y contrato generados en las variables de colección `{{empleadoId}}` y `{{contratoId}}` para que los siguientes pedidos las reutilicen automáticamente. También se provee `crud-tests.postman_collection.json` con ejemplos básicos para ejercitar las operaciones CRUD de todas las entidades de los microservicios. A partir de esta actualización se agregó `nomina-crud-tests.postman_collection.json`, un recorrido simplificado que crea un concepto de liquidación y genera la nómina. Esta colección ahora arranca creando el empleado y su contrato mediante la SAGA para obtener un `empleadoId` válido, asignarle el concepto y generar la nómina verificando que `servicio-consultas` reciba dichas novedades vía Kafka. También se agregó `openapi-tests.postman_collection.json`, una colección que verifica la disponibilidad de la documentación OpenAPI de cada microservicio.
+Todas las colecciones asumen que el punto de entrada es el API Gateway disponible en http://localhost:8080.
+
+Para eliminaciones, pasá tanto el id de empleado como el `contratoId` como parámetro de consulta, por ejemplo `DELETE /api/saga/empleado-contrato/5?contratoId=10`.
+Usá `GET /api/saga/empleado-contrato/{sagaId}` para inspeccionar el estado de una saga.
+
+Para verificar si se abre el circuit breaker de creación de empleado, hacé varios pedidos fallidos (por ejemplo deteniendo `servicio-empleado`) y luego enviá un `GET` a `http://localhost:8080/actuator/cb-state/crearEmpleadoCB?includeState=true`.
+El controlador `CircuitBreakerStatusController` expone de forma explícita el estado de cada breaker en esa URL `/actuator/cb-state/{name}`.
+
+La solicitud `Estado Circuit Breaker crearEmpleadoCB` de la colección de Postman espera que el estado del breaker sea `OPEN`.
+
+Para auditar los intentos de creación de empleado, consultá `GET http://localhost:8080/actuator/cb-state/empleado-actions`.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-consultas_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-consultas_README.adoc
@@ -1,0 +1,27 @@
+= Servicio Consultas
+
+Expone endpoints de consulta que se alimentan del resto de los servicios.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más información.
+
+== Endpoints principales
+
+* `GET /api/empleados` - Consulta de empleados.
+* `GET /api/empleados/{id}` - Detalle de empleado.
+* `GET /api/contratos` - Lista los contratos.
+* `GET /api/contratos/{id}` - Detalle de contrato.
+* `GET /api/liquidaciones` - Nóminas generadas.
+* `GET /api/liquidaciones/{id}` - Detalle de nómina.
+* `GET /api/turnos` - Turnos de capacitación.
+* `GET /api/jornadas` - Jornadas de entrenamiento.
+* `GET /api/asistencias` - Registro de asistencias.
+* `GET /api/conceptos` - Conceptos de liquidación existentes.
+
+== Comentarios
+
+Consume eventos de los demás servicios para mantener una vista de consultas actualizada. Los diagramas se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Este servicio también expone su contrato en `/v3/api-docs` con una interfaz
+`/swagger-ui.html` para explorarlo.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-contrato_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-contrato_README.adoc
@@ -1,0 +1,24 @@
+= Servicio Contrato
+
+Maneja la gestión de contratos de los empleados dentro del sistema.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más detalles de construcción y ejecución.
+
+== Endpoints principales
+
+* `POST /api/contratos` - Crea un contrato laboral para un empleado.
+* `GET /api/contratos` - Lista todos los contratos registrados.
+* `PUT /api/contratos/{id}` - Actualiza un contrato existente.
+* `DELETE /api/contratos/{id}` - Elimina un contrato por id.
+* `DELETE /api/contratos/empleado/{empleadoId}` - Borra los contratos de un empleado.
+
+== Comentarios
+
+Este servicio mantiene un registro local de empleados mediante eventos de Kafka
+para validar integridad referencial. Los diagramas de apoyo se hallan en
+`docs/uml/local`.
+
+== Documentación OpenAPI
+
+La especificación de la API está disponible en `/v3/api-docs` y puede
+explorarse con Swagger UI en `/swagger-ui.html`.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-empleado_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-empleado_README.adoc
@@ -1,0 +1,27 @@
+= Servicio Empleado
+
+Expone las operaciones CRUD de empleados.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más detalles.
+
+== Endpoints principales
+
+* `POST /api/empleados` - Alta de un empleado.
+* `GET /api/empleados` - Listado de empleados.
+* `GET /api/empleados/{id}` - Devuelve un empleado por id.
+* `GET /api/empleados/documento/{doc}` - Busca por documento.
+* `PUT /api/empleados/{id}` - Actualiza un empleado.
+* `DELETE /api/empleados/{id}` - Elimina el registro.
+* `GET /api/empleados/{id}/departamentos` - Departamentos asignados.
+* `GET /api/empleados/{id}/puestos` - Puestos ocupados.
+* `GET /api/empleados/{id}/documentaciones` - Documentación del legajo.
+* `GET /api/empleados/{id}/sindicatos` - Afiliaciones sindicales.
+
+== Comentarios
+
+Al crear, actualizar o eliminar un empleado se publican eventos en Kafka para que el resto de los microservicios se mantenga sincronizado. Los diagramas asociados se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Accedé a `/v3/api-docs` para obtener la especificación completa de esta API y a
+`/swagger-ui.html` para navegarla de forma interactiva.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-entrenamiento_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-entrenamiento_README.adoc
@@ -1,0 +1,30 @@
+= Servicio Entrenamiento
+
+Gestiona cursos y capacitaciones del personal.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para información de uso.
+
+== Configuración de Kafka
+
+Este servicio utiliza Kafka para publicar y consumir eventos. Por defecto se conecta a `localhost:9092`, pero podés sobrescribir la URL del broker con la variable de entorno `KAFKA_BOOTSTRAP_SERVERS` cuando lo ejecutes dentro de un contenedor (por ejemplo `kafka:9092`).
+
+Para detectar tempranamente problemas de conexión con Kafka se habilitó la propiedad `spring.kafka.admin.fail-fast=true`.
+
+== Endpoints principales
+
+* `POST /api/capacitaciones` - Alta de una capacitación.
+* `GET /api/capacitaciones` - Listado de capacitaciones.
+* `GET /api/capacitaciones/{id}` - Detalle de una capacitación.
+* `POST /api/evaluaciones` - Registro de evaluación.
+* `GET /api/evaluaciones` - Listado de evaluaciones.
+* `GET /api/evaluaciones/{id}` - Detalle de evaluación.
+
+== Comentarios
+
+Publica y consume eventos de capacitación y evaluación mediante Kafka.
+Los diagramas descriptivos están en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+La especificación expuesta en `/v3/api-docs` puede visualizarse con Swagger UI
+en `/swagger-ui.html`.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-nomina_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-nomina_README.adoc
@@ -1,0 +1,26 @@
+= Servicio Nómina
+
+Procesa pagos y recibos salariales.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para instrucciones generales.
+
+== Endpoints principales
+
+* `POST /api/conceptos` - Crea un concepto de liquidación.
+* `GET /api/conceptos` - Lista todos los conceptos.
+* `GET /api/conceptos/{id}` - Detalle de un concepto.
+* `POST /api/empleados/{empleadoId}/conceptos/{conceptoId}` - Asigna un concepto a un empleado.
+* `POST /api/liquidaciones` - Genera una liquidación.
+* `GET /api/liquidaciones` - Listado de liquidaciones.
+* `GET /api/liquidaciones/{id}` - Detalle de liquidación.
+* `POST /api/liquidaciones/{id}/calcular` - Calcula los importes de la nómina.
+
+== Comentarios
+
+Las operaciones emiten eventos a Kafka para que `servicio-consultas` refleje
+los cambios. Los diagramas de uso se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Consultá `/v3/api-docs` para la definición de la API y `/swagger-ui.html` para
+probar los endpoints.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-openapi-ui_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-openapi-ui_README.adoc
@@ -17,11 +17,3 @@ estén disponibles. De lo contrario, el visor mostrará un mensaje de error.
 Este módulo no expone controladores propios. Obtiene las especificaciones a través del API Gateway
 usando rutas como `http://localhost:8080/<servicio>/v3/api-docs`, lo que permite resolver los
 destinos dinámicamente mediante Eureka y balanceo de carga.
-
-== Documentación AsciiDoc
-
-Además de las especificaciones OpenAPI, este servicio ahora incluye todas las
-guías en AsciiDoc de cada módulo. Desde la página principal podés acceder a un
-enlace llamado *Ver documentación AsciiDoc* que abre un visor interactivo. Allí
-se procesan los archivos `README.adoc` de los diferentes servicios usando
-Asciidoctor.js directamente en el navegador.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-orquestador_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servicio-orquestador_README.adoc
@@ -1,0 +1,24 @@
+= Servicio Orquestador
+
+Este módulo contiene la lógica de orquestación de las operaciones de RRHH. Forma parte del proyecto de microservicios descrito en el README principal del repositorio.
+
+Consultá `../README.adoc` para obtener información general de construcción y ejecución.
+
+== Endpoints principales
+
+* `POST /api/saga/empleado-contrato` - Inicia la SAGA de creación de empleado y contrato.
+* `PUT /api/saga/empleado-contrato/{id}` - Actualiza empleado y contrato de forma coordinada.
+* `DELETE /api/saga/empleado-contrato/{id}?contratoId=XX` - Elimina ambos registros.
+* `GET /api/saga/empleado-contrato/{id}` - Consulta el estado de una SAGA.
+* `GET /api/saga/operaciones` - Lista las operaciones registradas por saga.
+* `GET /actuator/cb-state/{name}` - Estado de los circuit breakers.
+* `GET /actuator/cb-state/empleado-actions` - Historial de intentos de creación.
+
+== Comentarios
+
+Coordina los demás microservicios mediante un flujo SAGA basado en máquinas de estados. Utiliza Feign y Kafka para comunicarse con `servicio-empleado` y `servicio-contrato`. Ver diagramas en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+La descripción completa de los endpoints está disponible en `/v3/api-docs` y
+puede consultarse gráficamente en `/swagger-ui.html`.

--- a/servicio-openapi-ui/src/main/resources/static/asciidoc/servidor-para-descubrimiento_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/asciidoc/servidor-para-descubrimiento_README.adoc
@@ -1,0 +1,21 @@
+= Servidor para Descubrimiento
+
+Servidor dedicado al registro y descubrimiento de los microservicios.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para obtener instrucciones generales.
+
+== Endpoints principales
+
+Eureka expone una interfaz web en `http://localhost:8761` desde donde se pueden
+ver las instancias registradas. No posee endpoints propios fuera de lo
+provisto por Spring.
+
+== Comentarios
+
+Los demás servicios se registran aquí para que el gateway pueda localizarlos. Los diagramas se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+A pesar de no exponer controladores propios, este módulo publica `/v3/api-docs`
+y `/swagger-ui.html` de forma vacía para mantener uniformidad con el resto del
+proyecto.

--- a/servicio-openapi-ui/src/main/resources/static/docs.html
+++ b/servicio-openapi-ui/src/main/resources/static/docs.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Documentación AsciiDoc</title>
+  <script src="https://cdn.jsdelivr.net/npm/asciidoctor@2/dist/browser/asciidoctor.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    header { background: #004080; color: white; padding: 1em; }
+    header h1 { margin: 0; font-size: 1.5em; }
+    #selector { margin: 1em; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Documentación AsciiDoc</h1>
+  </header>
+  <div id="selector">
+    <label for="doc-select">Documento:</label>
+    <select id="doc-select">
+      <option value="root_README.adoc">README del proyecto</option>
+      <option value="API-gateway_README.adoc">API-gateway</option>
+      <option value="comunes_README.adoc">comunes</option>
+      <option value="servicio-consultas_README.adoc">servicio-consultas</option>
+      <option value="servicio-contrato_README.adoc">servicio-contrato</option>
+      <option value="servicio-empleado_README.adoc">servicio-empleado</option>
+      <option value="servicio-entrenamiento_README.adoc">servicio-entrenamiento</option>
+      <option value="servicio-nomina_README.adoc">servicio-nomina</option>
+      <option value="servicio-orquestador_README.adoc">servicio-orquestador</option>
+      <option value="servidor-para-descubrimiento_README.adoc">servidor-para-descubrimiento</option>
+      <option value="servicio-openapi-ui_README.adoc">servicio-openapi-ui</option>
+    </select>
+  </div>
+  <div id="adoc-content"></div>
+  <script>
+    const asciidoctor = Asciidoctor();
+    const select = document.getElementById('doc-select');
+    const content = document.getElementById('adoc-content');
+
+    function loadDoc(name) {
+      fetch('asciidoc/' + name)
+        .then(resp => resp.text())
+        .then(text => {
+          content.innerHTML = asciidoctor.convert(text);
+        })
+        .catch(err => {
+          content.innerHTML = '<p>Error al cargar el documento.</p>';
+          console.error(err);
+        });
+    }
+
+    select.addEventListener('change', () => loadDoc(select.value));
+    loadDoc(select.value);
+  </script>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -14,6 +14,9 @@
 <body>
   <header>
     <h1>Documentación OpenAPI de RRHH</h1>
+    <nav>
+      <a href="docs.html" style="color: white;">Ver documentación AsciiDoc</a>
+    </nav>
   </header>
   <div id="selector">
     <label for="service-select">Servicio:</label>


### PR DESCRIPTION
## Summary
- add docs.html with an AsciiDoc viewer powered by Asciidoctor.js
- link to the new viewer from the main index.html
- ship all README.adoc files inside the OpenAPI UI module
- document AsciiDoc usage in the README

## Testing
- `mvn test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686cde36ff6883248ea543c426d9ea6b