### PR TITLE
Arreglar el cargador AsciiDoc cuando se sirve a través de la puerta de enlace

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -38,7 +38,7 @@
     const adocContent = document.getElementById('adoc-content');
 
     function loadDoc(name) {
-      fetch('asciidoc/' + name)
+      fetch('/asciidoc/' + name)
         .then(resp => resp.text())
         .then(text => {
           adocContent.innerHTML = asciidoctor.convert(text);


### PR DESCRIPTION
## Summary
- ensure the openapi-ui loads AsciiDoc files using absolute path

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686ce36a0b9c83249be7f7244d749107