### PR TITLE
Fix AsciiDoc and OpenAPI loading

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -38,8 +38,13 @@
     const adocContent = document.getElementById('adoc-content');
 
     function loadDoc(name) {
-      fetch('/asciidoc/' + name)
-        .then(resp => resp.text())
+      return fetch('/asciidoc/' + name)
+        .then(resp => {
+          if (!resp.ok) {
+            throw new Error('HTTP ' + resp.status);
+          }
+          return resp.text();
+        })
         .then(text => {
           adocContent.innerHTML = asciidoctor.convert(text);
         })
@@ -70,12 +75,13 @@
 
     function loadAll() {
       const option = select.selectedOptions[0];
-      loadDoc(option.getAttribute('data-doc'));
-      loadSpec(option.value);
+      loadDoc(option.getAttribute('data-doc')).then(() => {
+        loadSpec(option.value);
+      });
     }
 
     select.addEventListener('change', loadAll);
-    loadAll();
+    document.addEventListener('DOMContentLoaded', loadAll);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure HTML UI loads AsciiDoc before fetching the OpenAPI spec
- call loader on DOMContentLoaded and return fetch promises

## Testing
- `./mvnw -q -pl servicio-openapi-ui test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686ce6f4a3888324b7e928618bb56184