### PR TITLE
Fix AsciiDoc loading when behind gateway

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -38,7 +38,9 @@
     const adocContent = document.getElementById('adoc-content');
 
     function loadDoc(name) {
-      return fetch('/asciidoc/' + name)
+      // Relative path so it works whether the service is behind
+      // the API gateway (e.g. /servicio-openapi-ui) or standalone
+      return fetch('asciidoc/' + name)
         .then(resp => {
           if (!resp.ok) {
             throw new Error('HTTP ' + resp.status);


### PR DESCRIPTION
## Summary
- fix OpenAPI UI path so documentation loads when service is routed through the gateway

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce9ac78448324a0a772b405f85296