### PR TITLE
Fix docs load behind gateway

### DIFF
--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -25,3 +25,14 @@ guías en AsciiDoc de cada módulo. Al seleccionar un servicio en la página
 principal, primero se muestran estos documentos y luego la
 documentación OpenAPI correspondiente. Los archivos `README.adoc` se
 procesan con Asciidoctor.js directamente en el navegador.
+Si la biblioteca no se puede cargar desde Internet, el visor aplica un
+fallback integrado que muestra el texto sin formato.
+
+== Despliegue detrás del API Gateway
+
+Si esta interfaz se publica en una ruta como `/servicio-openapi-ui` a través
+del API Gateway, los archivos AsciiDoc deben solicitarse mediante una ruta
+relativa. La función `loadDoc` de `index.html` usa `fetch('asciidoc/' + name)`
+para garantizar que la documentación se cargue tanto en modo independiente
+como detrás del Gateway. Si los documentos no se muestran, revisá que este
+detalle esté presente.

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -5,6 +5,23 @@
   <title>Documentación OpenAPI RRHH</title>
   <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/asciidoctor@2/dist/browser/asciidoctor.min.js"></script>
+  <script>
+    // Fallback simple renderer in case the Asciidoctor CDN cannot be loaded
+    if (typeof Asciidoctor === 'undefined') {
+      console.warn('Asciidoctor.js no disponible; usando visor simplificado');
+      window.Asciidoctor = function () {
+        return {
+          convert: function (text) {
+            return '<pre>' +
+              text.replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/>/g, '&gt;') +
+              '</pre>';
+          }
+        };
+      };
+    }
+  </script>
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
     header { background: #004080; color: white; padding: 1em; }


### PR DESCRIPTION
## Summary
- document the relative path requirement when deploying OpenAPI UI behind the gateway
- include fallback Asciidoctor implementation when CDN fails

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686ceb5eed788324803e5c84337750f5