### PR TITLE
Corregir el complemento maven-antrun cuando faltan documentos

### DIFF
--- a/servicio-openapi-ui/pom.xml
+++ b/servicio-openapi-ui/pom.xml
@@ -139,7 +139,9 @@
                             <target>
                                 <mkdir dir="${project.build.outputDirectory}/static/html"/>
                                 <copy todir="${project.build.outputDirectory}/static/html">
-                                    <fileset dir="${project.build.directory}/generated-docs" includes="**/README.html"/>
+                                    <fileset dir="${project.build.directory}/generated-docs"
+                                            includes="**/README.html"
+                                            erroronmissingdir="false"/>
                                     <mapper type="glob" from="*/README.html" to="*_README.html"/>
                                 </copy>
                             </target>


### PR DESCRIPTION
## Summary
- prevent maven-antrun from failing when generated HTML docs are absent

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686cf686de188324b009c7635564ccf0