### PR TITLE
Corregir la carga de AsciiDoc en la interfaz de usuario de OpenAPI

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/adoc/API-gateway_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/API-gateway_README.adoc
@@ -1,0 +1,61 @@
+= API Gateway
+
+Encamina las peticiones entrantes hacia los diferentes microservicios de RRHH.
+
+Forma parte del proyecto de microservicios. Consultá `../README.adoc` para detalles generales.
+
+Este servicio actúa como balanceador de carga utilizando Spring Cloud Gateway y Eureka. Todas las solicitudes pasan por aquí para enrutarse correctamente.
+
+== Rutas principales
+
+Las reglas de enrutamiento están definidas en `application.properties`. En general las operaciones de escritura (`POST`, `PUT`, `DELETE`) van al microservicio correspondiente y las consultas (`GET`) al `servicio-consultas`.
+
+* `/api/empleados/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-empleado`
+** `GET` -> `servicio-consultas`
+* `/api/contratos/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/jornadas/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/turnos/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/asistencias/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/licencias/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/vacaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-contrato`
+** `GET` -> `servicio-consultas`
+* `/api/capacitaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/evaluaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-entrenamiento`
+** `GET` -> `servicio-consultas`
+* `/api/liquidaciones/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-nomina`
+** `GET` -> `servicio-consultas`
+* `/api/conceptos/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-nomina`
+** `GET` -> `servicio-consultas`
+* `/api/empleados/{id}/conceptos/**`
+** `POST` -> `servicio-nomina`
+* `/api/saga/**`
+** `POST`, `PUT`, `DELETE` -> `servicio-orquestador`
+** `GET` -> `servicio-orquestador`
+* `/actuator/cb-state/**`
+** `GET` -> `servicio-orquestador`
+
+== Comentarios
+
+El gateway se registra en Eureka y aplica balanceo de carga para cada ruta. Es el punto de entrada sugerido para integrar clientes externos. Los diagramas están en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Swagger UI está disponible en `/swagger-ui.html` y expone la descripción de las
+rutas en `/v3/api-docs`.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servicio-consultas_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servicio-consultas_README.adoc
@@ -1,0 +1,27 @@
+= Servicio Consultas
+
+Expone endpoints de consulta que se alimentan del resto de los servicios.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más información.
+
+== Endpoints principales
+
+* `GET /api/empleados` - Consulta de empleados.
+* `GET /api/empleados/{id}` - Detalle de empleado.
+* `GET /api/contratos` - Lista los contratos.
+* `GET /api/contratos/{id}` - Detalle de contrato.
+* `GET /api/liquidaciones` - Nóminas generadas.
+* `GET /api/liquidaciones/{id}` - Detalle de nómina.
+* `GET /api/turnos` - Turnos de capacitación.
+* `GET /api/jornadas` - Jornadas de entrenamiento.
+* `GET /api/asistencias` - Registro de asistencias.
+* `GET /api/conceptos` - Conceptos de liquidación existentes.
+
+== Comentarios
+
+Consume eventos de los demás servicios para mantener una vista de consultas actualizada. Los diagramas se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Este servicio también expone su contrato en `/v3/api-docs` con una interfaz
+`/swagger-ui.html` para explorarlo.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servicio-contrato_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servicio-contrato_README.adoc
@@ -1,0 +1,24 @@
+= Servicio Contrato
+
+Maneja la gestión de contratos de los empleados dentro del sistema.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más detalles de construcción y ejecución.
+
+== Endpoints principales
+
+* `POST /api/contratos` - Crea un contrato laboral para un empleado.
+* `GET /api/contratos` - Lista todos los contratos registrados.
+* `PUT /api/contratos/{id}` - Actualiza un contrato existente.
+* `DELETE /api/contratos/{id}` - Elimina un contrato por id.
+* `DELETE /api/contratos/empleado/{empleadoId}` - Borra los contratos de un empleado.
+
+== Comentarios
+
+Este servicio mantiene un registro local de empleados mediante eventos de Kafka
+para validar integridad referencial. Los diagramas de apoyo se hallan en
+`docs/uml/local`.
+
+== Documentación OpenAPI
+
+La especificación de la API está disponible en `/v3/api-docs` y puede
+explorarse con Swagger UI en `/swagger-ui.html`.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servicio-empleado_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servicio-empleado_README.adoc
@@ -1,0 +1,27 @@
+= Servicio Empleado
+
+Expone las operaciones CRUD de empleados.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para más detalles.
+
+== Endpoints principales
+
+* `POST /api/empleados` - Alta de un empleado.
+* `GET /api/empleados` - Listado de empleados.
+* `GET /api/empleados/{id}` - Devuelve un empleado por id.
+* `GET /api/empleados/documento/{doc}` - Busca por documento.
+* `PUT /api/empleados/{id}` - Actualiza un empleado.
+* `DELETE /api/empleados/{id}` - Elimina el registro.
+* `GET /api/empleados/{id}/departamentos` - Departamentos asignados.
+* `GET /api/empleados/{id}/puestos` - Puestos ocupados.
+* `GET /api/empleados/{id}/documentaciones` - Documentación del legajo.
+* `GET /api/empleados/{id}/sindicatos` - Afiliaciones sindicales.
+
+== Comentarios
+
+Al crear, actualizar o eliminar un empleado se publican eventos en Kafka para que el resto de los microservicios se mantenga sincronizado. Los diagramas asociados se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Accedé a `/v3/api-docs` para obtener la especificación completa de esta API y a
+`/swagger-ui.html` para navegarla de forma interactiva.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servicio-entrenamiento_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servicio-entrenamiento_README.adoc
@@ -1,0 +1,30 @@
+= Servicio Entrenamiento
+
+Gestiona cursos y capacitaciones del personal.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para información de uso.
+
+== Configuración de Kafka
+
+Este servicio utiliza Kafka para publicar y consumir eventos. Por defecto se conecta a `localhost:9092`, pero podés sobrescribir la URL del broker con la variable de entorno `KAFKA_BOOTSTRAP_SERVERS` cuando lo ejecutes dentro de un contenedor (por ejemplo `kafka:9092`).
+
+Para detectar tempranamente problemas de conexión con Kafka se habilitó la propiedad `spring.kafka.admin.fail-fast=true`.
+
+== Endpoints principales
+
+* `POST /api/capacitaciones` - Alta de una capacitación.
+* `GET /api/capacitaciones` - Listado de capacitaciones.
+* `GET /api/capacitaciones/{id}` - Detalle de una capacitación.
+* `POST /api/evaluaciones` - Registro de evaluación.
+* `GET /api/evaluaciones` - Listado de evaluaciones.
+* `GET /api/evaluaciones/{id}` - Detalle de evaluación.
+
+== Comentarios
+
+Publica y consume eventos de capacitación y evaluación mediante Kafka.
+Los diagramas descriptivos están en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+La especificación expuesta en `/v3/api-docs` puede visualizarse con Swagger UI
+en `/swagger-ui.html`.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servicio-nomina_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servicio-nomina_README.adoc
@@ -1,0 +1,26 @@
+= Servicio Nómina
+
+Procesa pagos y recibos salariales.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para instrucciones generales.
+
+== Endpoints principales
+
+* `POST /api/conceptos` - Crea un concepto de liquidación.
+* `GET /api/conceptos` - Lista todos los conceptos.
+* `GET /api/conceptos/{id}` - Detalle de un concepto.
+* `POST /api/empleados/{empleadoId}/conceptos/{conceptoId}` - Asigna un concepto a un empleado.
+* `POST /api/liquidaciones` - Genera una liquidación.
+* `GET /api/liquidaciones` - Listado de liquidaciones.
+* `GET /api/liquidaciones/{id}` - Detalle de liquidación.
+* `POST /api/liquidaciones/{id}/calcular` - Calcula los importes de la nómina.
+
+== Comentarios
+
+Las operaciones emiten eventos a Kafka para que `servicio-consultas` refleje
+los cambios. Los diagramas de uso se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+Consultá `/v3/api-docs` para la definición de la API y `/swagger-ui.html` para
+probar los endpoints.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servicio-orquestador_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servicio-orquestador_README.adoc
@@ -1,0 +1,24 @@
+= Servicio Orquestador
+
+Este módulo contiene la lógica de orquestación de las operaciones de RRHH. Forma parte del proyecto de microservicios descrito en el README principal del repositorio.
+
+Consultá `../README.adoc` para obtener información general de construcción y ejecución.
+
+== Endpoints principales
+
+* `POST /api/saga/empleado-contrato` - Inicia la SAGA de creación de empleado y contrato.
+* `PUT /api/saga/empleado-contrato/{id}` - Actualiza empleado y contrato de forma coordinada.
+* `DELETE /api/saga/empleado-contrato/{id}?contratoId=XX` - Elimina ambos registros.
+* `GET /api/saga/empleado-contrato/{id}` - Consulta el estado de una SAGA.
+* `GET /api/saga/operaciones` - Lista las operaciones registradas por saga.
+* `GET /actuator/cb-state/{name}` - Estado de los circuit breakers.
+* `GET /actuator/cb-state/empleado-actions` - Historial de intentos de creación.
+
+== Comentarios
+
+Coordina los demás microservicios mediante un flujo SAGA basado en máquinas de estados. Utiliza Feign y Kafka para comunicarse con `servicio-empleado` y `servicio-contrato`. Ver diagramas en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+La descripción completa de los endpoints está disponible en `/v3/api-docs` y
+puede consultarse gráficamente en `/swagger-ui.html`.

--- a/servicio-openapi-ui/src/main/resources/static/adoc/servidor-para-descubrimiento_README.adoc
+++ b/servicio-openapi-ui/src/main/resources/static/adoc/servidor-para-descubrimiento_README.adoc
@@ -1,0 +1,21 @@
+= Servidor para Descubrimiento
+
+Servidor dedicado al registro y descubrimiento de los microservicios.
+
+Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` para obtener instrucciones generales.
+
+== Endpoints principales
+
+Eureka expone una interfaz web en `http://localhost:8761` desde donde se pueden
+ver las instancias registradas. No posee endpoints propios fuera de lo
+provisto por Spring.
+
+== Comentarios
+
+Los demás servicios se registran aquí para que el gateway pueda localizarlos. Los diagramas se encuentran en `docs/uml/local`.
+
+== Documentación OpenAPI
+
+A pesar de no exponer controladores propios, este módulo publica `/v3/api-docs`
+y `/swagger-ui.html` de forma vacía para mantener uniformidad con el resto del
+proyecto.

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Documentación OpenAPI RRHH</title>
   <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/asciidoctor@2.2.6/dist/browser/asciidoctor.min.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
     header { background: #004080; color: white; padding: 1em; }
@@ -35,9 +36,11 @@
     const select = document.getElementById('service-select');
 
     function loadDoc(name) {
+      // Convert expected HTML name to the corresponding AsciiDoc file
+      const adocName = name.replace(/\.html$/, '.adoc');
       // Relative path so it works whether the service is behind
       // the API gateway (e.g. /servicio-openapi-ui) or standalone
-      return fetch('html/' + name)
+      return fetch('adoc/' + adocName)
         .then(resp => {
           if (!resp.ok) {
             throw new Error('HTTP ' + resp.status);
@@ -45,7 +48,8 @@
           return resp.text();
         })
         .then(text => {
-          document.getElementById('adoc-content').innerHTML = text;
+          const html = Opal.Asciidoctor.$convert(text);
+          document.getElementById('adoc-content').innerHTML = html;
         })
         .catch(err => {
           document.getElementById('adoc-content').innerHTML = '<p>Error al cargar la documentación.</p>';


### PR DESCRIPTION
## Summary
- serve AsciiDoc files directly instead of pre-generated HTML
- embed Asciidoc files for all services
- convert docs on the client using Asciidoctor.js

## Testing
- `./mvnw -q -DskipTests package` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686d003351008324b1fba9ad02f167f1