### PR TITLE
Configurar Eureka sin self-preservation

### DIFF
--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -16,4 +16,7 @@ eureka.client.fetch-registry=false
 # registrarse y buscar el registro de servicios
 eureka.client.service-url.defaultZone=http://${eureka.instance.hostname}:${server.port}/eureka/
 
+# Desactivar modo de auto preservación para que se eliminen las instancias que no envíen renovaciones
+eureka.server.enable-self-preservation=false
+
 springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servidor_para_descubrimiento


### PR DESCRIPTION
## Summary
- disable self-preservation in discovery server to avoid EMERGENCY warnings

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686cffb04d848324a643e140ad341527