### PR TITLE
Fix docs loading without CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ logs/
 # Ignore all logs directories
 **/logs/
 
-# Generated HTML docs
-servicio-openapi-ui/src/main/resources/static/html/*README.html

--- a/servicio-openapi-ui/src/main/resources/static/html/API-gateway_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/API-gateway_README.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>API Gateway</h1>
+<br>
+<p>Encamina las peticiones entrantes hacia los diferentes microservicios de RRHH.</p>
+<br>
+<p>Forma parte del proyecto de microservicios. Consultá <code>../README.adoc</code> para detalles generales.</p>
+<br>
+<p>Este servicio actúa como balanceador de carga utilizando Spring Cloud Gateway y Eureka. Todas las solicitudes pasan por aquí para enrutarse correctamente.</p>
+<br>
+<h2>Rutas principales</h2>
+<br>
+<p>Las reglas de enrutamiento están definidas en <code>application.properties</code>. En general las operaciones de escritura (<code>POST</code>, <code>PUT</code>, <code>DELETE</code>) van al microservicio correspondiente y las consultas (<code>GET</code>) al <code>servicio-consultas</code>.</p>
+<br>
+<ul>
+<li><code>/api/empleados/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-empleado</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/contratos/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-contrato</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/jornadas/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-entrenamiento</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/turnos/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-entrenamiento</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/asistencias/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-contrato</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/licencias/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-contrato</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/vacaciones/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-contrato</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/capacitaciones/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-entrenamiento</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/evaluaciones/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-entrenamiento</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/liquidaciones/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-nomina</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/conceptos/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-nomina</code></li>
+<li><code>GET</code> -> <code>servicio-consultas</code></li>
+</ul>
+<li><code>/api/empleados/{id}/conceptos/**</code></li>
+<ul>
+<li><code>POST</code> -> <code>servicio-nomina</code></li>
+</ul>
+<li><code>/api/saga/**</code></li>
+<ul>
+<li><code>POST</code>, <code>PUT</code>, <code>DELETE</code> -> <code>servicio-orquestador</code></li>
+<li><code>GET</code> -> <code>servicio-orquestador</code></li>
+</ul>
+<li><code>/actuator/cb-state/**</code></li>
+<ul>
+<li><code>GET</code> -> <code>servicio-orquestador</code></li>
+</ul>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>El gateway se registra en Eureka y aplica balanceo de carga para cada ruta. Es el punto de entrada sugerido para integrar clientes externos. Los diagramas están en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>Swagger UI está disponible en <code>/swagger-ui.html</code> y expone la descripción de las</p>
+<p>rutas en <code>/v3/api-docs</code>.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servicio-consultas_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servicio-consultas_README.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servicio Consultas</h1>
+<br>
+<p>Expone endpoints de consulta que se alimentan del resto de los servicios.</p>
+<br>
+<p>Forma parte del proyecto de microservicios de RRHH. Consultá <code>../README.adoc</code> para más información.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<ul>
+<li><code>GET /api/empleados</code> - Consulta de empleados.</li>
+<li><code>GET /api/empleados/{id}</code> - Detalle de empleado.</li>
+<li><code>GET /api/contratos</code> - Lista los contratos.</li>
+<li><code>GET /api/contratos/{id}</code> - Detalle de contrato.</li>
+<li><code>GET /api/liquidaciones</code> - Nóminas generadas.</li>
+<li><code>GET /api/liquidaciones/{id}</code> - Detalle de nómina.</li>
+<li><code>GET /api/turnos</code> - Turnos de capacitación.</li>
+<li><code>GET /api/jornadas</code> - Jornadas de entrenamiento.</li>
+<li><code>GET /api/asistencias</code> - Registro de asistencias.</li>
+<li><code>GET /api/conceptos</code> - Conceptos de liquidación existentes.</li>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Consume eventos de los demás servicios para mantener una vista de consultas actualizada. Los diagramas se encuentran en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>Este servicio también expone su contrato en <code>/v3/api-docs</code> con una interfaz</p>
+<p><code>/swagger-ui.html</code> para explorarlo.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servicio-contrato_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servicio-contrato_README.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servicio Contrato</h1>
+<br>
+<p>Maneja la gestión de contratos de los empleados dentro del sistema.</p>
+<br>
+<p>Forma parte del proyecto de microservicios de RRHH. Consultá <code>../README.adoc</code> para más detalles de construcción y ejecución.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<ul>
+<li><code>POST /api/contratos</code> - Crea un contrato laboral para un empleado.</li>
+<li><code>GET /api/contratos</code> - Lista todos los contratos registrados.</li>
+<li><code>PUT /api/contratos/{id}</code> - Actualiza un contrato existente.</li>
+<li><code>DELETE /api/contratos/{id}</code> - Elimina un contrato por id.</li>
+<li><code>DELETE /api/contratos/empleado/{empleadoId}</code> - Borra los contratos de un empleado.</li>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Este servicio mantiene un registro local de empleados mediante eventos de Kafka</p>
+<p>para validar integridad referencial. Los diagramas de apoyo se hallan en</p>
+<p><code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>La especificación de la API está disponible en <code>/v3/api-docs</code> y puede</p>
+<p>explorarse con Swagger UI en <code>/swagger-ui.html</code>.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servicio-empleado_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servicio-empleado_README.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servicio Empleado</h1>
+<br>
+<p>Expone las operaciones CRUD de empleados.</p>
+<br>
+<p>Forma parte del proyecto de microservicios de RRHH. Consultá <code>../README.adoc</code> para más detalles.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<ul>
+<li><code>POST /api/empleados</code> - Alta de un empleado.</li>
+<li><code>GET /api/empleados</code> - Listado de empleados.</li>
+<li><code>GET /api/empleados/{id}</code> - Devuelve un empleado por id.</li>
+<li><code>GET /api/empleados/documento/{doc}</code> - Busca por documento.</li>
+<li><code>PUT /api/empleados/{id}</code> - Actualiza un empleado.</li>
+<li><code>DELETE /api/empleados/{id}</code> - Elimina el registro.</li>
+<li><code>GET /api/empleados/{id}/departamentos</code> - Departamentos asignados.</li>
+<li><code>GET /api/empleados/{id}/puestos</code> - Puestos ocupados.</li>
+<li><code>GET /api/empleados/{id}/documentaciones</code> - Documentación del legajo.</li>
+<li><code>GET /api/empleados/{id}/sindicatos</code> - Afiliaciones sindicales.</li>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Al crear, actualizar o eliminar un empleado se publican eventos en Kafka para que el resto de los microservicios se mantenga sincronizado. Los diagramas asociados se encuentran en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>Accedé a <code>/v3/api-docs</code> para obtener la especificación completa de esta API y a</p>
+<p><code>/swagger-ui.html</code> para navegarla de forma interactiva.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servicio-entrenamiento_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servicio-entrenamiento_README.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servicio Entrenamiento</h1>
+<br>
+<p>Gestiona cursos y capacitaciones del personal.</p>
+<br>
+<p>Forma parte del proyecto de microservicios de RRHH. Consultá <code>../README.adoc</code> para información de uso.</p>
+<br>
+<h2>Configuración de Kafka</h2>
+<br>
+<p>Este servicio utiliza Kafka para publicar y consumir eventos. Por defecto se conecta a <code>localhost:9092</code>, pero podés sobrescribir la URL del broker con la variable de entorno <code>KAFKA_BOOTSTRAP_SERVERS</code> cuando lo ejecutes dentro de un contenedor (por ejemplo <code>kafka:9092</code>).</p>
+<br>
+<p>Para detectar tempranamente problemas de conexión con Kafka se habilitó la propiedad <code>spring.kafka.admin.fail-fast=true</code>.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<ul>
+<li><code>POST /api/capacitaciones</code> - Alta de una capacitación.</li>
+<li><code>GET /api/capacitaciones</code> - Listado de capacitaciones.</li>
+<li><code>GET /api/capacitaciones/{id}</code> - Detalle de una capacitación.</li>
+<li><code>POST /api/evaluaciones</code> - Registro de evaluación.</li>
+<li><code>GET /api/evaluaciones</code> - Listado de evaluaciones.</li>
+<li><code>GET /api/evaluaciones/{id}</code> - Detalle de evaluación.</li>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Publica y consume eventos de capacitación y evaluación mediante Kafka.</p>
+<p>Los diagramas descriptivos están en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>La especificación expuesta en <code>/v3/api-docs</code> puede visualizarse con Swagger UI</p>
+<p>en <code>/swagger-ui.html</code>.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servicio-nomina_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servicio-nomina_README.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servicio Nómina</h1>
+<br>
+<p>Procesa pagos y recibos salariales.</p>
+<br>
+<p>Forma parte del proyecto de microservicios de RRHH. Consultá <code>../README.adoc</code> para instrucciones generales.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<ul>
+<li><code>POST /api/conceptos</code> - Crea un concepto de liquidación.</li>
+<li><code>GET /api/conceptos</code> - Lista todos los conceptos.</li>
+<li><code>GET /api/conceptos/{id}</code> - Detalle de un concepto.</li>
+<li><code>POST /api/empleados/{empleadoId}/conceptos/{conceptoId}</code> - Asigna un concepto a un empleado.</li>
+<li><code>POST /api/liquidaciones</code> - Genera una liquidación.</li>
+<li><code>GET /api/liquidaciones</code> - Listado de liquidaciones.</li>
+<li><code>GET /api/liquidaciones/{id}</code> - Detalle de liquidación.</li>
+<li><code>POST /api/liquidaciones/{id}/calcular</code> - Calcula los importes de la nómina.</li>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Las operaciones emiten eventos a Kafka para que <code>servicio-consultas</code> refleje</p>
+<p>los cambios. Los diagramas de uso se encuentran en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>Consultá <code>/v3/api-docs</code> para la definición de la API y <code>/swagger-ui.html</code> para</p>
+<p>probar los endpoints.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servicio-orquestador_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servicio-orquestador_README.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servicio Orquestador</h1>
+<br>
+<p>Este módulo contiene la lógica de orquestación de las operaciones de RRHH. Forma parte del proyecto de microservicios descrito en el README principal del repositorio.</p>
+<br>
+<p>Consultá <code>../README.adoc</code> para obtener información general de construcción y ejecución.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<ul>
+<li><code>POST /api/saga/empleado-contrato</code> - Inicia la SAGA de creación de empleado y contrato.</li>
+<li><code>PUT /api/saga/empleado-contrato/{id}</code> - Actualiza empleado y contrato de forma coordinada.</li>
+<li><code>DELETE /api/saga/empleado-contrato/{id}?contratoId=XX</code> - Elimina ambos registros.</li>
+<li><code>GET /api/saga/empleado-contrato/{id}</code> - Consulta el estado de una SAGA.</li>
+<li><code>GET /api/saga/operaciones</code> - Lista las operaciones registradas por saga.</li>
+<li><code>GET /actuator/cb-state/{name}</code> - Estado de los circuit breakers.</li>
+<li><code>GET /actuator/cb-state/empleado-actions</code> - Historial de intentos de creación.</li>
+</ul>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Coordina los demás microservicios mediante un flujo SAGA basado en máquinas de estados. Utiliza Feign y Kafka para comunicarse con <code>servicio-empleado</code> y <code>servicio-contrato</code>. Ver diagramas en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>La descripción completa de los endpoints está disponible en <code>/v3/api-docs</code> y</p>
+<p>puede consultarse gráficamente en <code>/swagger-ui.html</code>.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/html/servidor-para-descubrimiento_README.html
+++ b/servicio-openapi-ui/src/main/resources/static/html/servidor-para-descubrimiento_README.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Servidor para Descubrimiento</h1>
+<br>
+<p>Servidor dedicado al registro y descubrimiento de los microservicios.</p>
+<br>
+<p>Forma parte del proyecto de microservicios de RRHH. Consultá <code>../README.adoc</code> para obtener instrucciones generales.</p>
+<br>
+<h2>Endpoints principales</h2>
+<br>
+<p>Eureka expone una interfaz web en <code>http://localhost:8761</code> desde donde se pueden</p>
+<p>ver las instancias registradas. No posee endpoints propios fuera de lo</p>
+<p>provisto por Spring.</p>
+<br>
+<h2>Comentarios</h2>
+<br>
+<p>Los demás servicios se registran aquí para que el gateway pueda localizarlos. Los diagramas se encuentran en <code>docs/uml/local</code>.</p>
+<br>
+<h2>Documentación OpenAPI</h2>
+<br>
+<p>A pesar de no exponer controladores propios, este módulo publica <code>/v3/api-docs</code></p>
+<p>y <code>/swagger-ui.html</code> de forma vacía para mantener uniformidad con el resto del</p>
+<p>proyecto.</p>
+</body>
+</html>

--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>Documentación OpenAPI RRHH</title>
   <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/asciidoctor@2.2.6/dist/browser/asciidoctor.min.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
     header { background: #004080; color: white; padding: 1em; }
@@ -36,19 +35,15 @@
     const select = document.getElementById('service-select');
 
     function loadDoc(name) {
-      // Convert expected HTML name to the corresponding AsciiDoc file
-      const adocName = name.replace(/\.html$/, '.adoc');
-      // Relative path so it works whether the service is behind
-      // the API gateway (e.g. /servicio-openapi-ui) or standalone
-      return fetch('adoc/' + adocName)
+      // Carga directamente el HTML pre-generado
+      return fetch('html/' + name)
         .then(resp => {
           if (!resp.ok) {
             throw new Error('HTTP ' + resp.status);
           }
           return resp.text();
         })
-        .then(text => {
-          const html = Opal.Asciidoctor.$convert(text);
+        .then(html => {
           document.getElementById('adoc-content').innerHTML = html;
         })
         .catch(err => {

--- a/tools/adoc_to_html.py
+++ b/tools/adoc_to_html.py
@@ -1,0 +1,51 @@
+import os
+import re
+
+INPUT_DIR = 'servicio-openapi-ui/src/main/resources/static/adoc'
+OUTPUT_DIR = 'servicio-openapi-ui/src/main/resources/static/html'
+
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+for fname in os.listdir(INPUT_DIR):
+    if not fname.endswith('.adoc'):
+        continue
+    in_path = os.path.join(INPUT_DIR, fname)
+    out_path = os.path.join(OUTPUT_DIR, fname.replace('.adoc', '.html'))
+    html_lines = ['<!DOCTYPE html>', '<html>', '<body>']
+    in_ul = []
+    with open(in_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            line = re.sub(r'`([^`]+)`', r'<code>\1</code>', line)
+            if line.startswith('= '):
+                html_lines.append(f'<h1>{line[2:].strip()}</h1>')
+            elif line.startswith('== '):
+                html_lines.append(f'<h2>{line[3:].strip()}</h2>')
+            elif line.startswith('** '):
+                if len(in_ul) < 2:
+                    while len(in_ul) < 2:
+                        html_lines.append('<ul>')
+                        in_ul.append(True)
+                html_lines.append(f'<li>{line[3:].strip()}</li>')
+            elif line.startswith('* '):
+                if not in_ul:
+                    html_lines.append('<ul>')
+                    in_ul.append(True)
+                elif len(in_ul) > 1:
+                    while len(in_ul) > 1:
+                        html_lines.append('</ul>')
+                        in_ul.pop()
+                html_lines.append(f'<li>{line[2:].strip()}</li>')
+            elif not line.strip():
+                while in_ul:
+                    html_lines.append('</ul>')
+                    in_ul.pop()
+                html_lines.append('<br>')
+            else:
+                html_lines.append(f'<p>{line.strip()}</p>')
+    while in_ul:
+        html_lines.append('</ul>')
+        in_ul.pop()
+    html_lines.extend(['</body>', '</html>'])
+    with open(out_path, 'w', encoding='utf-8') as out:
+        out.write('\n'.join(html_lines))


### PR DESCRIPTION
## Summary
- drop external Asciidoctor dependency
- convert AsciiDoc files to static HTML
- serve the generated HTML docs from the OpenAPI UI
- helper script for regenerating docs

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686d0a34808c83248c6a90277764a15c