### PR TITLE
Fix asciidoctor plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,13 +284,7 @@
                             <sourceDirectory>${project.basedir}</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.outputDirectory}/static/html</outputDirectory>
-                            <sources>
-                                <directory>${project.basedir}</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.basedir}</directory>

--- a/servicio-openapi-ui/pom.xml
+++ b/servicio-openapi-ui/pom.xml
@@ -43,13 +43,7 @@
                             <sourceDirectory>${project.parent.basedir}</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/root</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}</directory>
@@ -71,13 +65,7 @@
                             <sourceDirectory>${project.parent.basedir}/API-gateway</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/API-gateway</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/API-gateway</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/API-gateway</directory>
@@ -99,13 +87,7 @@
                             <sourceDirectory>${project.parent.basedir}/comunes</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/comunes</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/comunes</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/comunes</directory>
@@ -127,13 +109,7 @@
                             <sourceDirectory>${project.parent.basedir}/servicio-contrato</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-contrato</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servicio-contrato</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servicio-contrato</directory>
@@ -155,13 +131,7 @@
                             <sourceDirectory>${project.parent.basedir}/servicio-empleado</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-empleado</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servicio-empleado</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servicio-empleado</directory>
@@ -183,13 +153,7 @@
                             <sourceDirectory>${project.parent.basedir}/servicio-entrenamiento</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-entrenamiento</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servicio-entrenamiento</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servicio-entrenamiento</directory>
@@ -211,13 +175,7 @@
                             <sourceDirectory>${project.parent.basedir}/servicio-nomina</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-nomina</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servicio-nomina</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servicio-nomina</directory>
@@ -239,13 +197,7 @@
                             <sourceDirectory>${project.parent.basedir}/servicio-orquestador</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-orquestador</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servicio-orquestador</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servicio-orquestador</directory>
@@ -267,13 +219,7 @@
                             <sourceDirectory>${project.parent.basedir}/servicio-consultas</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-consultas</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servicio-consultas</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servicio-consultas</directory>
@@ -295,13 +241,7 @@
                             <sourceDirectory>${project.parent.basedir}/servidor-para-descubrimiento</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servidor-para-descubrimiento</outputDirectory>
-                            <sources>
-                                <directory>${project.parent.basedir}/servidor-para-descubrimiento</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.parent.basedir}/servidor-para-descubrimiento</directory>
@@ -323,13 +263,7 @@
                             <sourceDirectory>${project.basedir}</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputDirectory>${project.build.directory}/generated-docs/servicio-openapi-ui</outputDirectory>
-                            <sources>
-                                <directory>${project.basedir}</directory>
-                                <excludes>
-                                    <exclude>**/.git/**</exclude>
-                                    <exclude>**/target/**</exclude>
-                                </excludes>
-                            </sources>
+                            <!-- Removed deprecated 'sources' configuration -->
                             <resources>
                                 <resource>
                                     <directory>${project.basedir}</directory>


### PR DESCRIPTION
## Summary
- remove outdated `sources` config from Asciidoctor plugin in the root pom
- remove deprecated `sources` parameter from all executions in `servicio-openapi-ui`

## Testing
- `./mvnw -q -pl servicio-openapi-ui -am process-resources` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686d16b13ee08324ae08b5f8fe3406f3