### PR TITLE
Adjust eureka renewal thresholds

### DIFF
--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -20,3 +20,7 @@ eureka.client.service-url.defaultZone=http://${eureka.instance.hostname}:${serve
 eureka.server.enable-self-preservation=false
 
 springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servidor_para_descubrimiento
+
+# Ajustes de renovación para evitar alertas por debajo del umbral
+eureka.server.expected-client-renewal-interval-seconds=30
+eureka.server.renewal-percent-threshold=0.49


### PR DESCRIPTION
## Summary
- tweak discovery server renewal configuration to avoid warnings

## Testing
- `./mvnw -q test` *(fails: NullPointerException in wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d3b7e308324a6aceacc3ca3a278