### PR TITLE
Activa auto preservación en Eureka

### DIFF
--- a/servidor-para-descubrimiento/README.adoc
+++ b/servidor-para-descubrimiento/README.adoc
@@ -14,6 +14,8 @@ provisto por Spring.
 
 Los demás servicios se registran aquí para que el gateway pueda localizarlos. Los diagramas se encuentran en `docs/uml/local`.
 
+Desde esta versión el modo de *auto preservación* de Eureka está habilitado para evitar que se eliminen instancias de forma prematura si hay problemas de red. Si observás el mensaje `THE SELF PRESERVATION MODE IS TURNED OFF` en los logs, verificá que `eureka.server.enable-self-preservation=true` esté configurado en `application.properties`.
+
 == Documentación OpenAPI
 
 A pesar de no exponer controladores propios, este módulo publica `/v3/api-docs`

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -16,8 +16,8 @@ eureka.client.fetch-registry=false
 # registrarse y buscar el registro de servicios
 eureka.client.service-url.defaultZone=http://${eureka.instance.hostname}:${server.port}/eureka/
 
-# Desactivar modo de auto preservación para que se eliminen las instancias que no envíen renovaciones
-eureka.server.enable-self-preservation=false
+# Activar el modo de auto preservación para evitar la expiración prematura de instancias ante problemas de red
+eureka.server.enable-self-preservation=true
 
 springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servidor_para_descubrimiento
 


### PR DESCRIPTION
## Summary
- enable Eureka self-preservation mode in `application.properties`
- mention the configuration in the discovery server README

## Testing
- `./mvnw -q test` *(fails: Cannot invoke "String.lastIndexOf(String)" because "path" is null)*

------
https://chatgpt.com/codex/tasks/task_e_686d1fa2009c83249ab651814a0e5a16