### PR TITLE
Mejorar la documentación de OpenAPI

### DIFF
--- a/comunes/pom.xml
+++ b/comunes/pom.xml
@@ -46,6 +46,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <!-- OpenAPI support to allow shared customizers -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
         <!-- Lombok para código más limpio -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/config/openapi/OperationIdCustomizer.java
+++ b/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/config/openapi/OperationIdCustomizer.java
@@ -1,0 +1,22 @@
+package ar.org.hospitalcuencaalta.comunes.config.openapi;
+
+import io.swagger.v3.oas.models.Operation;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * Adds a unique operationId using the controller name to avoid values like
+ * update_1 in the OpenAPI documentation.
+ */
+@Component
+public class OperationIdCustomizer implements OperationCustomizer {
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        String methodName = handlerMethod.getMethod().getName();
+        String controllerName = handlerMethod.getBeanType().getSimpleName()
+                .replace("Controller", "");
+        operation.setOperationId(methodName + controllerName);
+        return operation;
+    }
+}


### PR DESCRIPTION
## Summary
- share custom OpenAPI OperationId bean so method names are unique
- add springdoc-openapi to comunes module

## Testing
- `mvn -pl comunes -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686d22c935cc832486e7550eaa4f655e