### PR TITLE
Se solucionó el problema de limpieza y NPE del contenedor Maven

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -303,10 +303,9 @@ fi
 MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
 export MAVEN_CMD_LINE_ARGS
 
-WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+WRAPPER_MAVEN="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/apache-maven-3.9.9"
+if [ ! -d "$WRAPPER_MAVEN" ]; then
+  unzip -q "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/apache-maven-3.9.9-bin.zip" -d "$MAVEN_PROJECTBASEDIR/.mvn/wrapper"
+fi
 
-exec "$JAVACMD" \
-  $MAVEN_OPTS \
-  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
-  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
+exec "$WRAPPER_MAVEN/bin/mvn" $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -158,7 +158,11 @@ if exist %WRAPPER_JAR% (
 @REM work with both Windows and non-Windows executions.
 set MAVEN_CMD_LINE_ARGS=%*
 
-%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+set WRAPPER_MAVEN=%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\apache-maven-3.9.9
+if not exist "%WRAPPER_MAVEN%" (
+    powershell -Command "Expand-Archive -LiteralPath '%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\apache-maven-3.9.9-bin.zip' -DestinationPath '%MAVEN_PROJECTBASEDIR%\.mvn\wrapper'"
+)
+"%WRAPPER_MAVEN%\bin\mvn" %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/servicio-openapi-ui/pom.xml
+++ b/servicio-openapi-ui/pom.xml
@@ -218,7 +218,7 @@
                                 <mkdir dir="${project.build.outputDirectory}/static/html"/>
                                 <copy todir="${project.build.outputDirectory}/static/html">
                                     <fileset dir="${project.build.directory}/generated-docs"
-                                            includes="**/README.html"
+                                            includes="*/README.html"
                                             erroronmissingdir="false"/>
                                     <mapper type="glob" from="*/README.html" to="*_README.html"/>
                                 </copy>


### PR DESCRIPTION
## Summary
- update maven wrapper scripts to extract and use local Maven distro
- prevent nested generated-docs directories

## Testing
- `./mvnw -version`
- `./mvnw -q -DskipTests clean` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e484c1828832484f59c31e6c2c329