### PR TITLE
Agregar un panel de monitoreo personalizado

### DIFF
--- a/servidor-para-monitoreo/README.adoc
+++ b/servidor-para-monitoreo/README.adoc
@@ -12,3 +12,8 @@ podrás revisar health checks, métricas, logs y trazas de cada servicio registr
 
 Este servidor se registra en Eureka y los demás servicios utilizan el
 starter de cliente para reportar su estado automáticamente.
+
+== Interfaz personalizada
+
+Además de la consola de administración de Spring Boot Admin, este módulo incluye un tablero liviano en `http://localhost:9090/dashboard/`.
+Muestra en una tabla el estado, versión y última actualización de cada microservicio registrado.

--- a/servidor-para-monitoreo/src/main/resources/application.properties
+++ b/servidor-para-monitoreo/src/main/resources/application.properties
@@ -9,3 +9,5 @@ eureka.client.service-url.defaultZone=http://localhost:8761/eureka
 management.endpoints.web.exposure.include=*
 
 springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servidor_para_monitoreo
+
+# Acceso al tablero personalizado en /dashboard/

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/index.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Panel de Monitoreo</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.4/css/bulma.min.css">
+</head>
+<body>
+<section class="section">
+    <div class="container">
+        <h1 class="title">Panel de Monitoreo</h1>
+        <p class="subtitle">Estado detallado de los microservicios registrados</p>
+        <table class="table is-fullwidth" id="services-table">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Estado</th>
+                    <th>Versión</th>
+                    <th>Última Actualización</th>
+                </tr>
+            </thead>
+            <tbody id="services-body">
+            </tbody>
+        </table>
+    </div>
+</section>
+<script>
+async function loadServices() {
+    try {
+        const response = await fetch('/instances');
+        if (!response.ok) {
+            throw new Error('Error al obtener instancias: ' + response.status);
+        }
+        const data = await response.json();
+        const tbody = document.getElementById('services-body');
+        tbody.innerHTML = '';
+        for (const instance of data) {
+            const tr = document.createElement('tr');
+            const name = instance.registration?.name || 'N/A';
+            const status = instance.status || 'desconocido';
+            const version = instance.registration?.metadata?.buildVersion || 'N/A';
+            const update = instance.statusTimestamp ? new Date(instance.statusTimestamp).toLocaleString() : 'N/A';
+            tr.innerHTML = `<td>${name}</td><td>${status}</td><td>${version}</td><td>${update}</td>`;
+            tbody.appendChild(tr);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+}
+loadServices();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add lightweight dashboard for monitoring
- document how to access custom dashboard
- note new custom dashboard URL in application properties

## Testing
- `./mvnw -version`
- `./mvnw -q -pl servidor-para-monitoreo package -DskipTests` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e55b6b5cc83249874f4806e8ce52f