### PR TITLE
Introducir el perfil de compilación de documentos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,6 +59,14 @@ Desde la raíz del repositorio podés compilar todos los módulos a la vez:
 ./mvnw clean package
 ----
 
+Para generar la documentación AsciiDoc de todos los módulos, activá el perfil
+`docs` durante la compilación:
+
+[source,bash]
+----
+./mvnw clean package -Pdocs
+----
+
 == Ejecución de pruebas
 
 Ejecutá las pruebas de todos los módulos con:

--- a/pom.xml
+++ b/pom.xml
@@ -284,47 +284,57 @@
             </plugins>
         </pluginManagement>
         <plugins>
-            <plugin>
-                <groupId>org.asciidoctor</groupId>
-                <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <resources>
-                        <resource>
-                            <directory>${project.basedir}</directory>
-                            <excludes>
-                                <exclude>**/.git/**</exclude>
-                            </excludes>
-                        </resource>
-                    </resources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>convert-to-html</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>process-asciidoc</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirectory>${project.basedir}</sourceDirectory>
-                            <sourceDocumentName>README.adoc</sourceDocumentName>
-                            <outputDirectory>${project.build.outputDirectory}/static/html</outputDirectory>
-                            <!-- Removed deprecated 'sources' configuration -->
-                            <backend>html</backend>
-                            <doctype>book</doctype>
-                            <attributes>
-                                <snippets>${project.build.directory}/generated-snippets</snippets>
-                                <source-highlighter>coderay</source-highlighter>
-                                <imagesdir>./images</imagesdir>
-                                <toc>left</toc>
-                                <icons>font</icons>
-                            </attributes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>docs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}</directory>
+                                    <excludes>
+                                        <exclude>**/.git/**</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>convert-to-html</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>${project.basedir}</sourceDirectory>
+                                    <sourceDocumentName>README.adoc</sourceDocumentName>
+                                    <outputDirectory>${project.build.outputDirectory}/static/html</outputDirectory>
+                                    <!-- Removed deprecated 'sources' configuration -->
+                                    <backend>html</backend>
+                                    <doctype>book</doctype>
+                                    <attributes>
+                                        <snippets>${project.build.directory}/generated-snippets</snippets>
+                                        <source-highlighter>coderay</source-highlighter>
+                                        <imagesdir>./images</imagesdir>
+                                        <toc>left</toc>
+                                        <icons>font</icons>
+                                    </attributes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <repositories>
         <repository>

--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -27,6 +27,15 @@ documentación OpenAPI correspondiente. Los archivos `README.adoc`
 se convierten a HTML durante la compilación mediante el plugin
 Asciidoctor de Maven y se incluyen listos para su visualización.
 
+La generación de esta documentación puede omitirse para acelerar el
+proceso de compilación. Ejecutá el build con `-Pdocs` cuando necesites
+actualizar los HTML:
+
+[source,bash]
+----
+./mvnw clean package -Pdocs
+----
+
 == Despliegue detrás del API Gateway
 
 Si esta interfaz se publica en una ruta como `/servicio-openapi-ui` a través

--- a/servicio-openapi-ui/pom.xml
+++ b/servicio-openapi-ui/pom.xml
@@ -36,11 +36,19 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.asciidoctor</groupId>
-                <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>docs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
                     <execution>
                         <id>root-readme</id>
                         <phase>generate-resources</phase>
@@ -199,35 +207,37 @@
                             <!-- Removed deprecated 'sources' configuration -->
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
+                    </executions>
+                    </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-html</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <mkdir dir="${project.build.outputDirectory}/static/html"/>
-                                <copy todir="${project.build.outputDirectory}/static/html">
-                                    <fileset dir="${project.build.directory}/generated-docs"
-                                            includes="*/README.html"
-                                            erroronmissingdir="false"/>
-                                    <mapper type="glob" from="*/README.html" to="*_README.html"/>
-                                </copy>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy-html</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${project.build.outputDirectory}/static/html"/>
+                                        <copy todir="${project.build.outputDirectory}/static/html">
+                                            <fileset dir="${project.build.directory}/generated-docs"
+                                                    includes="*/README.html"
+                                                    erroronmissingdir="false"/>
+                                            <mapper type="glob" from="*/README.html" to="*_README.html"/>
+                                        </copy>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/servicio-orquestador/pom.xml
+++ b/servicio-orquestador/pom.xml
@@ -196,31 +196,6 @@
 <!--                </configuration>-->
 <!--            </plugin>-->
             <plugin>
-                <groupId>org.asciidoctor</groupId>
-                <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>generate-docs</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>process-asciidoc</goal>
-                        </goals>
-                        <configuration>
-                            <backend>html</backend>
-                            <doctype>book</doctype>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.springframework.restdocs</groupId>
-                        <artifactId>spring-restdocs-asciidoctor</artifactId>
-                        <version>${spring-restdocs.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
@@ -234,5 +209,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>docs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>generate-docs</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <backend>html</backend>
+                                    <doctype>book</doctype>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.springframework.restdocs</groupId>
+                                <artifactId>spring-restdocs-asciidoctor</artifactId>
+                                <version>${spring-restdocs.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 
 </project>


### PR DESCRIPTION
## Summary
- wrap Asciidoctor plugin in a new `docs` profile
- add the profile to `servicio-orquestador` and `servicio-openapi-ui`
- document how to enable the docs profile

## Testing
- `./mvnw -q -pl servicio-orquestador -am test` *(fails: Could not resolve Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_686e6bfd8de083249b24e413f916e2bf