### PR TITLE
Fix discovery server Swagger dependency

### DIFF
--- a/servidor-para-descubrimiento/pom.xml
+++ b/servidor-para-descubrimiento/pom.xml
@@ -96,6 +96,17 @@
             <artifactId>swagger-ui</artifactId>
             <version>5.21.0</version>
         </dependency>
+        <!-- Soporta anotaciones JAXB requeridas por swagger-core en Java 17+ -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.5</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>


### PR DESCRIPTION
## Summary
- add JAXB dependencies so swagger-core works on Java 17+

## Testing
- `./mvnw -q -pl servidor-para-descubrimiento -am test` *(fails: could not resolve dependencies, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e7aceba4c8324b6584cd8fdc8db27