### PR TITLE
Fix JAXB error in discovery server

### DIFF
--- a/servidor-para-descubrimiento/pom.xml
+++ b/servidor-para-descubrimiento/pom.xml
@@ -98,14 +98,14 @@
         </dependency>
         <!-- Soporta anotaciones JAXB requeridas por swagger-core en Java 17+ -->
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.2</version>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.5</version>
+            <version>2.3.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>


### PR DESCRIPTION
## Summary
- swap `jakarta.xml.bind` dependencies for `javax.xml.bind` so swagger-core can load `XmlElement`

## Testing
- `./mvnw -q -pl servidor-para-descubrimiento -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e8330bf208324af24ca2b1512d2f0