### PR TITLE
Configurar recursos de prueba locales y dependencias

### DIFF
--- a/API-gateway/src/test/resources/application.properties
+++ b/API-gateway/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+eureka.client.enabled=false

--- a/comunes/src/test/resources/application.properties
+++ b/comunes/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+eureka.client.enabled=false

--- a/servicio-consultas/pom.xml
+++ b/servicio-consultas/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- MapStruct & Lombok -->
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/servicio-consultas/src/test/resources/application.properties
+++ b/servicio-consultas/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+eureka.client.enabled=false
+spring.datasource.url=jdbc:h2:mem:consultas;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
+spring.kafka.listener.auto-startup=false

--- a/servicio-contrato/src/test/resources/application.properties
+++ b/servicio-contrato/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+eureka.client.enabled=false
+spring.datasource.url=jdbc:h2:mem:contrato;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
+spring.kafka.listener.auto-startup=false

--- a/servicio-empleado/pom.xml
+++ b/servicio-empleado/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>

--- a/servicio-empleado/src/test/resources/application.properties
+++ b/servicio-empleado/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+eureka.client.enabled=false
+spring.datasource.url=jdbc:h2:mem:empleado;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
+spring.kafka.listener.auto-startup=false

--- a/servicio-nomina/pom.xml
+++ b/servicio-nomina/pom.xml
@@ -55,6 +55,11 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- MapStruct & Lombok -->
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/servicio-nomina/src/test/resources/application.properties
+++ b/servicio-nomina/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+eureka.client.enabled=false
+spring.datasource.url=jdbc:h2:mem:nomina;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
+spring.kafka.listener.auto-startup=false

--- a/servicio-openapi-ui/src/test/resources/application.properties
+++ b/servicio-openapi-ui/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+eureka.client.enabled=false

--- a/servicio-orquestador/src/test/resources/application.properties
+++ b/servicio-orquestador/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+eureka.client.enabled=false
+spring.datasource.url=jdbc:h2:mem:orquestador;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
+spring.kafka.listener.auto-startup=false

--- a/servidor-para-descubrimiento/src/test/resources/application.properties
+++ b/servidor-para-descubrimiento/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false


### PR DESCRIPTION
## Summary
- add test `application.properties` disabling eureka and kafka, using H2
- add H2 as test dependency for modules missing it

## Testing
- `./mvnw -q -pl comunes test`

------
https://chatgpt.com/codex/tasks/task_e_686e8a9ed3c8832486903237f7fcdb48