### PR TITLE
Fix KafkaTemplate injection for domain events

### DIFF
--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/KafkaTemplateConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/KafkaTemplateConfig.java
@@ -15,4 +15,17 @@ public class KafkaTemplateConfig {
             ProducerFactory<String, Object> producerFactory) {
         return new KafkaTemplate(producerFactory);
     }
+
+    /**
+     * Generic {@link KafkaTemplate} bean used by components that publish
+     * different types of domain events. We expose it explicitly because the
+     * custom {@code compensacionKafkaTemplate} bean prevents Spring Boot's
+     * auto-configuration from creating the default template.
+     */
+    @Bean
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public KafkaTemplate<String, Object> kafkaTemplate(
+            ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate(producerFactory);
+    }
 }


### PR DESCRIPTION
## Summary
- provide a default `KafkaTemplate<String, Object>` bean

## Testing
- `./mvnw -q -pl servicio-orquestador test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e94e032b88324aae877ce00c57550