### PR TITLE
Se corrige la propiedad de tema de Kafka faltante para las pruebas de consultas.

### DIFF
--- a/servicio-consultas/src/test/resources/application.properties
+++ b/servicio-consultas/src/test/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
 spring.kafka.listener.auto-startup=false
+spring.kafka.topic.saga.compensated=saga.compensated


### PR DESCRIPTION
## Summary
- ensure test environment defines `spring.kafka.topic.saga.compensated`

## Testing
- `mvn -o -pl servicio-consultas -am test` *(fails: Non-resolvable parent POM due to offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_686e995b599c832498aa1f9d7dd10168