### PR TITLE
Se solucionó la falta de fábrica de Kafka en las pruebas

### DIFF
--- a/servicio-consultas/src/test/resources/application.properties
+++ b/servicio-consultas/src/test/resources/application.properties
@@ -6,3 +6,5 @@ spring.datasource.password=
 spring.liquibase.change-log=classpath:db/changelog/changelog-master.xml
 spring.kafka.listener.auto-startup=false
 spring.kafka.topic.saga.compensated=saga.compensated
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=test-group


### PR DESCRIPTION
## Summary
- add bootstrap server and consumer group to tests for servicio-consultas

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686e9abce0788324a643f4658832fc0d