### PR TITLE
Fix Spring Boot Admin poll timer property

### DIFF
--- a/servidor-para-monitoreo/src/main/resources/application.properties
+++ b/servidor-para-monitoreo/src/main/resources/application.properties
@@ -19,4 +19,10 @@ spring.boot.admin.discovery.enabled=false
 spring.boot.admin.ui.title=RRHH Monitor
 spring.boot.admin.ui.brand=RRHH Monitor
 # Actualizar datos de la consola con mayor frecuencia
-spring.boot.admin.ui.poll-timer=10000
+spring.boot.admin.ui.poll-timer.cache=10000
+spring.boot.admin.ui.poll-timer.datasource=10000
+spring.boot.admin.ui.poll-timer.gc=10000
+spring.boot.admin.ui.poll-timer.process=10000
+spring.boot.admin.ui.poll-timer.memory=10000
+spring.boot.admin.ui.poll-timer.threads=10000
+spring.boot.admin.ui.poll-timer.logfile=10000


### PR DESCRIPTION
## Summary
- fix incorrect property for Spring Boot Admin

## Testing
- `./mvnw -q -pl servidor-para-monitoreo test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686eaa0063e88324857d5ed00a071109