### PR TITLE
Agregar documentación detallada de microservicios

### DIFF
--- a/API-gateway/README.adoc
+++ b/API-gateway/README.adoc
@@ -59,3 +59,7 @@ El gateway se registra en Eureka y aplica balanceo de carga para cada ruta. Es e
 
 Swagger UI está disponible en `/swagger-ui.html` y expone la descripción de las
 rutas en `/v3/api-docs`.
+
+== Detalles de implementación
+
+El paquete `src/main/java` contiene un filtro de preprocesamiento en `config` que agrega encabezados de trazabilidad. Las reglas de enrutamiento se encuentran en `application.properties` y utilizan expresiones de Spring Cloud Gateway para mapear cada operación al servicio correspondiente. El gateway se registra en Eureka y aplica balanceo de carga mediante el patrón Proxy Inverso.

--- a/README.adoc
+++ b/README.adoc
@@ -117,3 +117,21 @@ El controlador `CircuitBreakerStatusController` expone de forma explícita el es
 La solicitud `Estado Circuit Breaker crearEmpleadoCB` de la colección de Postman espera que el estado del breaker sea `OPEN`.
 
 Para auditar los intentos de creación de empleado, consultá `GET http://localhost:8080/actuator/cb-state/empleado-actions`.
+
+== Información general de los microservicios
+
+Las responsabilidades de cada módulo y su ubicación principal se detallan a continuación. Se mencionan los patrones de diseño utilizados y la forma en que se comunican entre sí.
+
+* *servicio-empleado* -> se administra el CRUD de empleados en `servicio-empleado/src/main/java`. Se aplican controladores REST, repositorios JPA y mapeos con MapStruct. Cada cambio publica un `EmpleadoEventDto` en Kafka siguiendo el patrón de arquitectura orientada a eventos.
+* *servicio-contrato* -> se gestionan los contratos laborales en `servicio-contrato/src/main/java`. Se implementa el patrón Repositorio con Spring Data JPA y se mantienen registros locales de empleados. Se publican eventos contractuales a Kafka para sincronizar el resto del sistema.
+* *servicio-entrenamiento* -> se manejan capacitaciones y evaluaciones en `servicio-entrenamiento/src/main/java`. Las operaciones producen y consumen eventos por Kafka aplicando el patrón productor-consumidor.
+* *servicio-nomina* -> se realizan cálculos de nómina en `servicio-nomina/src/main/java`. Se notifican los resultados con eventos hacia `servicio-consultas`, aplicando el patrón Observador.
+* *servicio-consultas* -> se expone una vista optimizada para lectura en `servicio-consultas/src/main/java`. Se actualiza únicamente a partir de eventos, adoptando el patrón CQRS para separar comandos y consultas.
+* *servicio-orquestador* -> se coordina la creación de empleados y contratos en `servicio-orquestador/src/main/java` mediante un flujo SAGA basado en Spring StateMachine. Se comunica con los servicios correspondientes mediante Feign y publica el estado de la saga en Kafka.
+* *API-gateway* -> se encamina todo el tráfico en `API-gateway/src/main/java` utilizando Spring Cloud Gateway. Las rutas se definen en `application.properties` y se balancea la carga gracias a la integración con Eureka.
+* *servidor-para-descubrimiento* -> se ejecuta un servidor Eureka en `servidor-para-descubrimiento/src/main/java` para registrar cada microservicio.
+* *servidor-para-monitoreo* -> se centraliza el monitoreo en `servidor-para-monitoreo/src/main/java` a través de Spring Boot Admin. Los servicios reportan sus métricas automáticamente.
+* *servicio-openapi-ui* -> se sirve la documentación en `servicio-openapi-ui/src/main/java` mediante ReDoc. Las especificaciones se obtienen desde el API Gateway.
+* *comunes* -> se almacenan entidades y utilidades compartidas en `comunes/src/main/java`. Este módulo se utiliza como dependencia del resto.
+
+Los microservicios se comunican principalmente por HTTP a través del API Gateway y de forma asíncrona con eventos en Kafka. Cada servicio persiste su estado en bases MariaDB y `servicio-consultas` mantiene proyecciones de lectura. Los servidores de descubrimiento y monitoreo completan la infraestructura para garantizar escalabilidad y observabilidad.

--- a/comunes/README.adoc
+++ b/comunes/README.adoc
@@ -12,3 +12,7 @@ Incluye DTOs, mapeos y clases utilitarias utilizadas por los demás microservici
 
 No es un servicio independiente sino una dependencia común.
 Los diagramas que describen estas entidades están en `docs/uml/local`.
+
+== Detalles de implementación
+
+El código fuente se encuentra en `src/main/java`. Se definen paquetes de configuración como `config` que centralizan ajustes de Kafka, OpenAPI y web. Las clases DTO se agrupan en `dto` y comparten mapeos realizados con MapStruct. Esta biblioteca se incluye como dependencia en los demás servicios y permite reutilizar entidades y utilidades sin exponer un servicio adicional.

--- a/servicio-consultas/README.adoc
+++ b/servicio-consultas/README.adoc
@@ -25,3 +25,7 @@ Consume eventos de los demás servicios para mantener una vista de consultas act
 
 Este servicio también expone su contrato en `/v3/api-docs` con una interfaz
 `/swagger-ui.html` para explorarlo.
+
+== Detalles de implementación
+
+El código se organiza en `src/main/java` separando controladores de lectura en `controlador` y repositorios de proyecciones en `repositorio`. Cada servicio externo publica eventos que este módulo consume a través de Kafka para poblar sus tablas de consulta. Esta división sigue el patrón CQRS, ya que sólo se exponen operaciones de lectura mientras que las escrituras se procesan en los microservicios específicos.

--- a/servicio-contrato/README.adoc
+++ b/servicio-contrato/README.adoc
@@ -22,3 +22,7 @@ para validar integridad referencial. Los diagramas de apoyo se hallan en
 
 La especificación de la API está disponible en `/v3/api-docs` y puede
 explorarse con Swagger UI en `/swagger-ui.html`.
+
+== Detalles de implementación
+
+El código está ubicado en `src/main/java`. Se dividen los controladores en el paquete `controlador`, los servicios de negocio en `servicio` y los repositorios JPA en `repositorio`. Se aplica el patrón Repositorio para el acceso a datos y se utilizan mapeadores de MapStruct ubicados en `web.mapeo`. Al crear o actualizar un contrato se valida la existencia del empleado en la tabla local `empleado_registry` y se publica un mensaje `ContratoEventDto` en Kafka. Esta integración adopta el patrón Event Driven y mantiene sincronizado a `servicio-consultas`.

--- a/servicio-empleado/README.adoc
+++ b/servicio-empleado/README.adoc
@@ -25,3 +25,7 @@ Al crear, actualizar o eliminar un empleado se publican eventos en Kafka para qu
 
 Accedé a `/v3/api-docs` para obtener la especificación completa de esta API y a
 `/swagger-ui.html` para navegarla de forma interactiva.
+
+== Detalles de implementación
+
+El código fuente se aloja en `src/main/java`. Los controladores REST residen en `controlador`, los mapeadores de MapStruct en `web.mapeo` y los repositorios en `repositorio`. Se emplea JPA para la persistencia y se siguen patrones de DDD ligero. Cada modificación de un empleado genera un `EmpleadoEventDto` que se publica en Kafka, permitiendo que `servicio-consultas` escuche y actualice sus proyecciones. El acceso a la base se configura en `application.properties` y se registran las rutas en Eureka para que el API Gateway enrute las solicitudes.

--- a/servicio-entrenamiento/README.adoc
+++ b/servicio-entrenamiento/README.adoc
@@ -28,3 +28,7 @@ Los diagramas descriptivos están en `docs/uml/local`.
 
 La especificación expuesta en `/v3/api-docs` puede visualizarse con Swagger UI
 en `/swagger-ui.html`.
+
+== Detalles de implementación
+
+El código se encuentra en `src/main/java`. Los paquetes `controlador` y `servicio` encapsulan las operaciones REST y la lógica de negocio. Se usa Spring Data para persistir las entidades de capacitación y evaluación. Cada alta o modificación produce eventos `CapacitacionEventDto` o `EvaluacionEventDto` que se envían a Kafka, mientras que otros consumidores los procesan para mantener integridad. Esta mecánica implementa el patrón Productor-Consumidor.

--- a/servicio-nomina/README.adoc
+++ b/servicio-nomina/README.adoc
@@ -24,3 +24,7 @@ los cambios. Los diagramas de uso se encuentran en `docs/uml/local`.
 
 Consultá `/v3/api-docs` para la definición de la API y `/swagger-ui.html` para
 probar los endpoints.
+
+== Detalles de implementación
+
+El código reside en `src/main/java` y organiza controladores en `controlador`, servicios de dominio en `servicio` y repositorios en `repositorio`. Se implementan cálculos de importes dentro de los servicios y se mantienen entidades JPA para conceptos y liquidaciones. Al generar o recalcular una nómina se publica un `NominaEventDto` en Kafka de modo que `servicio-consultas` actualice sus proyecciones. Esta comunicación sigue el patrón Observador.

--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -44,3 +44,7 @@ relativa. La función `loadDoc` de `index.html` usa `fetch('html/' + name)`
 para garantizar que la documentación se cargue tanto en modo independiente
 como detrás del Gateway. Si los documentos no se muestran, revisá que este
 detalle esté presente.
+
+== Detalles de implementación
+
+El código fuente está en `src/main/java` y actúa como un front controller que entrega los documentos generados con Asciidoctor. Se construye una lista de servicios consultando Eureka vía el API Gateway y se carga cada especificación con `fetch`. Esta solución sigue el patrón Presentación Separada, donde la lógica de documento se mantiene aislada del resto de los servicios.

--- a/servicio-orquestador/README.adoc
+++ b/servicio-orquestador/README.adoc
@@ -22,3 +22,7 @@ Coordina los demás microservicios mediante un flujo SAGA basado en máquinas de
 
 La descripción completa de los endpoints está disponible en `/v3/api-docs` y
 puede consultarse gráficamente en `/swagger-ui.html`.
+
+== Detalles de implementación
+
+En `src/main/java` se definen las máquinas de estados en el paquete `statemachine` y los pasos de SAGA en `operacion`. Cada petición genera una nueva instancia de `StateMachine` que coordina las llamadas a `servicio-empleado` y `servicio-contrato` mediante clientes Feign. Los eventos de avance se publican en Kafka para notificar el resultado a otros componentes. Se sigue el patrón SAGA de orquestación y se exponen métricas a través de Micrometer.

--- a/servidor-para-descubrimiento/README.adoc
+++ b/servidor-para-descubrimiento/README.adoc
@@ -21,3 +21,7 @@ Desde esta versión el modo de *auto preservación* de Eureka está habilitado p
 A pesar de no exponer controladores propios, este módulo publica `/v3/api-docs`
 y `/swagger-ui.html` de forma vacía para mantener uniformidad con el resto del
 proyecto.
+
+== Detalles de implementación
+
+El código se encuentra en `src/main/java` e inicia un servidor Eureka mediante la anotación `@EnableEurekaServer`. No posee lógica adicional y sólo expone la consola en `http://localhost:8761` para visualizar las instancias registradas. Esta pieza aplica el patrón Registro de Servicio.

--- a/servidor-para-monitoreo/README.adoc
+++ b/servidor-para-monitoreo/README.adoc
@@ -20,3 +20,7 @@ Eureka para evitar registros duplicados en la consola de administración.
 
 Además de la consola de administración de Spring Boot Admin, este módulo incluye un tablero liviano en `http://localhost:9090/dashboard/`.
 Ahora se muestran también el consumo de CPU y memoria de cada servicio, junto con gráficos simples que se actualizan de forma manual con el botón *Refrescar*.
+
+== Detalles de implementación
+
+El código se ubica en `src/main/java` y registra la aplicación como cliente de Eureka para que los microservicios puedan reportar su estado. Se personalizan las vistas estáticas en `src/main/resources/static` y se aprovecha Spring Boot Admin para aplicar el patrón Tablero de Monitoreo. Las métricas se recogen por Actuator y se presentan en la consola web.


### PR DESCRIPTION
## Summary
- expand general README with detailed overview of each module
- enhance each service README with implementation details

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686eb021a8b483249699394957f517c2