### PR TITLE
Aclarar el paso de compilación de documentos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,15 @@ páginas HTML se regenerarán solo cuando sea necesario y no en cada build:
 ./mvnw clean package -Pdocs
 ----
 
+La conversión de los README se ejecuta en el módulo
+`servicio-openapi-ui`. Si ejecutás Maven desde la raíz asegurate de
+incluir ese proyecto o, de forma directa, ejecutá:
+
+[source,bash]
+----
+(cd servicio-openapi-ui && ../mvnw clean package -Pdocs)
+----
+
 == Ejecución de pruebas
 
 Ejecutá las pruebas de todos los módulos con:


### PR DESCRIPTION
## Summary
- clarify that README conversion runs in `servicio-openapi-ui`
- show how to run `mvn -Pdocs` from that module

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f99fd9bb48324b2b40203262307a3