### PR TITLE
Corregir la compilación de la documentación de Maven detrás de un proxy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,8 +72,13 @@ páginas HTML se regenerarán solo cuando sea necesario y no en cada build:
 
 [source,bash]
 ----
-./mvnw clean package -Pdocs
+./mvnw clean package -Pdocs \
+       -s maven-settings.xml
 ----
+
+El archivo `maven-settings.xml` configura el proxy utilizado
+durante la descarga de dependencias. Podés copiarlo a tu `~/.m2/settings.xml`
+o pasarlo con la opción `-s` como en el ejemplo.
 
 La conversión de los README se ejecuta en el módulo
 `servicio-openapi-ui`. Si ejecutás Maven desde la raíz asegurate de
@@ -81,7 +86,8 @@ incluir ese proyecto o, de forma directa, ejecutá:
 
 [source,bash]
 ----
-(cd servicio-openapi-ui && ../mvnw clean package -Pdocs)
+(cd servicio-openapi-ui && ../mvnw clean package -Pdocs \
+    -s ../maven-settings.xml)
 ----
 
 == Ejecución de pruebas

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -1,0 +1,18 @@
+<settings>
+  <proxies>
+    <proxy>
+      <id>proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+    <proxy>
+      <id>https-proxy</id>
+      <active>true</active>
+      <protocol>https</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+  </proxies>
+</settings>


### PR DESCRIPTION
## Summary
- add `maven-settings.xml` with proxy configuration
- document how to use the settings file when regenerating docs

## Testing
- `./mvnw -Pdocs -pl servicio-openapi-ui -am -DskipTests clean package`
- `./mvnw -q -DskipITs test` *(failed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686f9fb244248324b48b7761a79a0391