### PR TITLE
Corregir el proceso de copia de documentos en service-openapi-ui

### DIFF
--- a/servicio-openapi-ui/pom.xml
+++ b/servicio-openapi-ui/pom.xml
@@ -223,6 +223,7 @@
                                 </goals>
                                 <configuration>
                                     <target>
+                                        <delete dir="${project.build.outputDirectory}/static/html"/>
                                         <mkdir dir="${project.build.outputDirectory}/static/html"/>
                                        <copy todir="${project.build.outputDirectory}/static/html">
                                            <fileset dir="${project.build.directory}/generated-docs"
@@ -230,6 +231,7 @@
                                                    erroronmissingdir="false"/>
                                            <mapper type="glob" from="*/README.html" to="*_README.html"/>
                                        </copy>
+                                       <delete dir="${project.basedir}/src/main/resources/static/html"/>
                                        <mkdir dir="${project.basedir}/src/main/resources/static/html"/>
                                        <copy todir="${project.basedir}/src/main/resources/static/html">
                                            <fileset dir="${project.build.directory}/generated-docs"


### PR DESCRIPTION
## Summary
- remove old static HTML before copying new docs

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.apache.maven.surefire:surefire-junit-platform:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_686fa9b248d48324ab2e6753a3e71200