### PR TITLE
Fix docs loading behind gateway

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -11,7 +11,9 @@
   </header>
   <div id="content"></div>
   <script>
-    fetch('html/rrhh_README.html')
+    const basePath = window.location.pathname.replace(/[^\/]*$/, '');
+    document.getElementById('link-microservicios').href = basePath + 'microservicios.html';
+    fetch(basePath + 'html/rrhh_README.html')
       .then(resp => resp.text())
       .then(html => {
         document.getElementById('content').innerHTML = html;

--- a/servicio-openapi-ui/src/main/resources/static/microservicios.html
+++ b/servicio-openapi-ui/src/main/resources/static/microservicios.html
@@ -33,10 +33,11 @@
   <script>
     let container = document.getElementById('redoc-container');
     const select = document.getElementById('service-select');
+    const basePath = window.location.pathname.replace(/[^\/]*$/, '');
 
     function loadDoc(name) {
       // Carga directamente el HTML pre-generado
-      return fetch('html/' + name)
+      return fetch(basePath + 'html/' + name)
         .then(resp => {
           if (!resp.ok) {
             throw new Error('HTTP ' + resp.status);


### PR DESCRIPTION
## Summary
- adjust static UI pages to calculate base path dynamically when served behind API Gateway

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686fb7b0f09483249806444ec1abfcf6