### PR TITLE
Fix documentation pages

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -11,9 +11,7 @@
   </header>
   <div id="content"></div>
   <script>
-    const basePath = window.location.pathname.replace(/[^\/]*$/, '');
-    document.getElementById('link-microservicios').href = basePath + 'microservicios.html';
-    fetch(basePath + 'html/rrhh_README.html')
+    fetch('html/rrhh_README.html')
       .then(resp => resp.text())
       .then(html => {
         document.getElementById('content').innerHTML = html;

--- a/servicio-openapi-ui/src/main/resources/static/microservicios.html
+++ b/servicio-openapi-ui/src/main/resources/static/microservicios.html
@@ -12,8 +12,9 @@
   </style>
 </head>
 <body>
-  <header>
+  <header style="display:flex;justify-content:space-between;align-items:center;">
     <h1>Documentación OpenAPI de RRHH</h1>
+    <a id="link-indice" href="index.html"><strong>Volver</strong></a>
   </header>
   <div id="selector">
     <label for="service-select">Servicio:</label>
@@ -33,11 +34,10 @@
   <script>
     let container = document.getElementById('redoc-container');
     const select = document.getElementById('service-select');
-    const basePath = window.location.pathname.replace(/[^\/]*$/, '');
 
     function loadDoc(name) {
       // Carga directamente el HTML pre-generado
-      return fetch(basePath + 'html/' + name)
+      return fetch('html/' + name)
         .then(resp => {
           if (!resp.ok) {
             throw new Error('HTTP ' + resp.status);


### PR DESCRIPTION
## Summary
- restore simpler relative path for docs on index page
- add link back to main index from microservices page
- remove unnecessary base path logic

## Testing
- `mvn -q -pl servicio-openapi-ui -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686fbdfbd548832480fc2d15c87fd7c4