### PR TITLE
Fix docs build on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,7 @@
                                     <directory>${project.basedir}</directory>
                                     <excludes>
                                         <exclude>**/.git/**</exclude>
+                                        <exclude>**/target/**</exclude>
                                     </excludes>
                                 </resource>
                             </resources>


### PR DESCRIPTION
## Summary
- exclude `target` directories from Asciidoctor resources

## Testing
- `./mvnw -q test -DskipITs` *(fails: connection to Kafka localhost:9092 could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_686fca3f11988324b13261d191f3b840