### PR TITLE
Fix docs path resolution

### DIFF
--- a/servicio-openapi-ui/src/main/resources/static/index.html
+++ b/servicio-openapi-ui/src/main/resources/static/index.html
@@ -11,7 +11,9 @@
   </header>
   <div id="content"></div>
   <script>
-    fetch('html/rrhh_README.html')
+    const basePath = window.location.pathname.replace(/[^\/]*$/, '');
+    document.getElementById('link-microservicios').href = basePath + 'microservicios.html';
+    fetch(basePath + 'html/rrhh_README.html')
       .then(resp => resp.text())
       .then(html => {
         document.getElementById('content').innerHTML = html;

--- a/servicio-openapi-ui/src/main/resources/static/microservicios.html
+++ b/servicio-openapi-ui/src/main/resources/static/microservicios.html
@@ -34,10 +34,12 @@
   <script>
     let container = document.getElementById('redoc-container');
     const select = document.getElementById('service-select');
+    const basePath = window.location.pathname.replace(/[^\/]*$/, '');
+    document.getElementById('link-indice').href = basePath + 'index.html';
 
     function loadDoc(name) {
       // Carga directamente el HTML pre-generado
-      return fetch('html/' + name)
+      return fetch(basePath + 'html/' + name)
         .then(resp => {
           if (!resp.ok) {
             throw new Error('HTTP ' + resp.status);


### PR DESCRIPTION
## Summary
- ensure docs load correctly when `servicio-openapi-ui` is served from a subpath

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686fce9d15088324ac775f179ce049f7