### PR TITLE
Add OpenAPI configuration and docs

### DIFF
--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/config/ConsultasOpenApiConfig.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/config/ConsultasOpenApiConfig.java
@@ -1,0 +1,21 @@
+package ar.org.hospitalcuencaalta.servicio_consultas.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de OpenAPI para el Servicio Consultas.
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Servicio Consultas",
+                version = "v1",
+                description = "Expone endpoints de consulta alimentados por otros servicios.",
+                contact = @Contact(name = "Equipo RRHH", email = "rrhh@example.com")
+        )
+)
+public class ConsultasOpenApiConfig {
+}

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/AsistenciaQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/AsistenciaQueryController.java
@@ -7,21 +7,26 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/asistencias")
+@Tag(name = "Consulta Asistencias", description = "Consultas de asistencias registradas")
 public class AsistenciaQueryController {
     @Autowired
     private AsistenciaProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar asistencias", description = "Obtiene todas las asistencias registradas")
     public List<AsistenciaProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Asistencia por id", description = "Devuelve una asistencia específica")
     public AsistenciaProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/ConceptoLiquidacionQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/ConceptoLiquidacionQueryController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
@@ -17,16 +19,19 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/conceptos")
+@Tag(name = "Consulta Conceptos", description = "Consultas de conceptos de liquidación")
 public class ConceptoLiquidacionQueryController {
     @Autowired
     private ConceptoLiquidacionProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar conceptos", description = "Devuelve todos los conceptos de liquidación")
     public List<ConceptoLiquidacionProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Concepto por id", description = "Obtiene un concepto de liquidación")
     public ConceptoLiquidacionProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/ContratoQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/ContratoQueryController.java
@@ -7,21 +7,26 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/contratos")
+@Tag(name = "Consulta Contratos", description = "Consultas de contratos laborales")
 public class ContratoQueryController {
     @Autowired
     private ContratoProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar contratos", description = "Devuelve todos los contratos registrados")
     public List<ContratoProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Contrato por id", description = "Obtiene un contrato en particular")
     public ContratoProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/EmpleadoQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/EmpleadoQueryController.java
@@ -7,21 +7,26 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/empleados")
+@Tag(name = "Consulta Empleados", description = "Consultas de proyección de empleados")
 public class EmpleadoQueryController {
     @Autowired
     private EmpleadoProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar empleados", description = "Obtiene la vista de todos los empleados")
     public List<EmpleadoProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Empleado por id", description = "Devuelve la proyección de un empleado")
     public EmpleadoProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/JornadaQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/JornadaQueryController.java
@@ -7,21 +7,26 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/jornadas")
+@Tag(name = "Consulta Jornadas", description = "Consultas de jornadas laborales")
 public class JornadaQueryController {
     @Autowired
     private JornadaProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar jornadas", description = "Obtiene todas las jornadas laborales")
     public List<JornadaProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Jornada por id", description = "Devuelve la jornada laboral solicitada")
     public JornadaProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/LiquidacionQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/LiquidacionQueryController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
@@ -15,16 +17,19 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/liquidaciones")
+@Tag(name = "Consulta Liquidaciones", description = "Consultas de liquidaciones generadas")
 public class LiquidacionQueryController {
     @Autowired
     private LiquidacionProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar liquidaciones", description = "Devuelve todas las liquidaciones")
     public List<LiquidacionProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Liquidación por id", description = "Obtiene una liquidación en particular")
     public LiquidacionProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/TurnoQueryController.java
+++ b/servicio-consultas/src/main/java/ar/org/hospitalcuencaalta/servicio_consultas/controlador/TurnoQueryController.java
@@ -7,21 +7,26 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/turnos")
+@Tag(name = "Consulta Turnos", description = "Consultas de turnos asignados")
 public class TurnoQueryController {
     @Autowired
     private TurnoProjectionRepository repo;
 
     @GetMapping
+    @Operation(summary = "Listar turnos", description = "Devuelve todos los turnos asignados")
     public List<TurnoProjection> all() {
         return repo.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Turno por id", description = "Obtiene el turno especificado")
     public TurnoProjection get(@PathVariable Long id) {
         return repo.findById(id).orElseThrow();
     }

--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/config/ContratoOpenApiConfig.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/config/ContratoOpenApiConfig.java
@@ -1,0 +1,21 @@
+package ar.org.hospitalcuencaalta.servicio_contrato.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de OpenAPI para el Servicio Contrato.
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Servicio Contrato",
+                version = "v1",
+                description = "Maneja la gestión de contratos de los empleados.",
+                contact = @Contact(name = "Equipo RRHH", email = "rrhh@example.com")
+        )
+)
+public class ContratoOpenApiConfig {
+}

--- a/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/controlador/ContratoController.java
+++ b/servicio-contrato/src/main/java/ar/org/hospitalcuencaalta/servicio_contrato/controlador/ContratoController.java
@@ -4,36 +4,44 @@ import ar.org.hospitalcuencaalta.servicio_contrato.servicio.ContratoService;
 import ar.org.hospitalcuencaalta.servicio_contrato.web.dto.ContratoLaboralDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/contratos")
 @RequiredArgsConstructor
+@Tag(name = "Contratos", description = "Operaciones sobre contratos laborales")
 public class ContratoController {
     private final ContratoService svc;
 
     @PostMapping
+    @Operation(summary = "Crear contrato", description = "Registra un nuevo contrato laboral")
     public ContratoLaboralDto create(@RequestBody ContratoLaboralDto dto) {
         return svc.create(dto);
     }
 
     @GetMapping
+    @Operation(summary = "Listar contratos", description = "Obtiene todos los contratos guardados")
     public List<ContratoLaboralDto> all() {
         return svc.findAll();
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Actualizar contrato", description = "Modifica los datos de un contrato")
     public ContratoLaboralDto update(@PathVariable Long id, @RequestBody ContratoLaboralDto dto) {
         return svc.update(id, dto);
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar contrato", description = "Elimina un contrato por su identificador")
     public void delete(@PathVariable Long id) {
         svc.delete(id);
     }
 
     @DeleteMapping("/empleado/{empleadoId}")
+    @Operation(summary = "Eliminar por empleado", description = "Borra contratos asociados al empleado dado")
     public void deleteByEmpleadoId(@PathVariable Long empleadoId) {
         svc.deleteByEmpleadoId(empleadoId);
     }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/config/EmpleadoOpenApiConfig.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/config/EmpleadoOpenApiConfig.java
@@ -1,0 +1,21 @@
+package ar.org.hospitalcuencaalta.servicio_empleado.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de OpenAPI para documentar el Servicio Empleado.
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Servicio Empleado",
+                version = "v1",
+                description = "Expone las operaciones CRUD de empleados.",
+                contact = @Contact(name = "Equipo RRHH", email = "rrhh@example.com")
+        )
+)
+public class EmpleadoOpenApiConfig {
+}

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DepartamentoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DepartamentoController.java
@@ -6,21 +6,26 @@ import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DepartamentoDetalleDt
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/empleados/{empleadoId}/departamentos")
 @RequiredArgsConstructor
+@Tag(name = "Departamentos", description = "Gestión de departamentos del empleado")
 public class DepartamentoController {
 
     private final DepartamentoService svc;
 
     @PostMapping
+    @Operation(summary = "Crear departamento", description = "Agrega un departamento al empleado")
     public DepartamentoDto create(@PathVariable Long empleadoId,
                                   @RequestBody DepartamentoDto dto) {
         return svc.create(empleadoId, dto);
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Actualizar departamento", description = "Modifica un departamento del empleado")
     public DepartamentoDto update(@PathVariable Long empleadoId,
                                   @PathVariable Long id,
                                   @RequestBody DepartamentoDto dto) {
@@ -28,18 +33,21 @@ public class DepartamentoController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar departamento", description = "Quita un departamento del empleado")
     public void delete(@PathVariable Long empleadoId,
                        @PathVariable Long id) {
         svc.delete(empleadoId, id);
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de departamento", description = "Obtiene un departamento específico")
     public DepartamentoDetalleDto get(@PathVariable Long empleadoId,
                                       @PathVariable Long id) {
         return svc.get(empleadoId, id);
     }
 
     @GetMapping("/detalle")
+    @Operation(summary = "Departamentos detallados", description = "Lista departamentos del empleado con detalle")
     public Page<DepartamentoDetalleDto> allDetailed(@PathVariable Long empleadoId,
                                                     @RequestParam(defaultValue = "0") Integer page,
                                                     @RequestParam(defaultValue = "10") Integer size) {
@@ -47,6 +55,7 @@ public class DepartamentoController {
     }
 
     @GetMapping
+    @Operation(summary = "Listar departamentos", description = "Lista departamentos del empleado")
     public Page<DepartamentoDto> all(@PathVariable Long empleadoId,
                                      @RequestParam(defaultValue = "0") Integer page,
                                      @RequestParam(defaultValue = "10") Integer size) {

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DocumentacionController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/DocumentacionController.java
@@ -6,21 +6,26 @@ import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.DocumentacionDetalleD
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/empleados/{empleadoId}/documentaciones")
 @RequiredArgsConstructor
+@Tag(name = "Documentaciones", description = "Gestión de documentación del empleado")
 public class DocumentacionController {
 
     private final DocumentacionService svc;
 
     @PostMapping
+    @Operation(summary = "Crear documentación", description = "Agrega un registro documental al empleado")
     public DocumentacionDto create(@PathVariable Long empleadoId,
                                    @RequestBody DocumentacionDto dto) {
         return svc.create(empleadoId, dto);
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Actualizar documentación", description = "Modifica un registro documental del empleado")
     public DocumentacionDto update(@PathVariable Long empleadoId,
                                    @PathVariable Long id,
                                    @RequestBody DocumentacionDto dto) {
@@ -28,18 +33,21 @@ public class DocumentacionController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar documentación", description = "Quita un registro documental del empleado")
     public void delete(@PathVariable Long empleadoId,
                        @PathVariable Long id) {
         svc.delete(empleadoId, id);
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de documentación", description = "Obtiene la documentación indicada")
     public DocumentacionDetalleDto get(@PathVariable Long empleadoId,
                                        @PathVariable Long id) {
         return svc.get(empleadoId, id);
     }
 
     @GetMapping("/detalle")
+    @Operation(summary = "Documentación detallada", description = "Lista la documentación del empleado con detalle")
     public Page<DocumentacionDetalleDto> allDetailed(@PathVariable Long empleadoId,
                                                      @RequestParam(defaultValue = "0") Integer page,
                                                      @RequestParam(defaultValue = "10") Integer size) {
@@ -47,6 +55,7 @@ public class DocumentacionController {
     }
 
     @GetMapping
+    @Operation(summary = "Listar documentación", description = "Devuelve la documentación asociada al empleado")
     public Page<DocumentacionDto> all(@PathVariable Long empleadoId,
                                       @RequestParam(defaultValue = "0") Integer page,
                                       @RequestParam(defaultValue = "10") Integer size) {

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/EmpleadoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/EmpleadoController.java
@@ -2,6 +2,8 @@ package ar.org.hospitalcuencaalta.servicio_empleado.controlador;
 
 import ar.org.hospitalcuencaalta.servicio_empleado.servicio.EmpleadoService;
 import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.EmpleadoDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,36 +11,43 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/empleados")
+@Tag(name = "Empleados", description = "Operaciones CRUD de empleados")
 public class EmpleadoController {
     @Autowired
     private EmpleadoService svc;
 
     @PostMapping
+    @Operation(summary = "Crear empleado", description = "Registra un nuevo empleado")
     public EmpleadoDto create(@RequestBody EmpleadoDto dto) {
         return svc.create(dto);
     }
 
     @GetMapping
+    @Operation(summary = "Listar empleados", description = "Devuelve todos los empleados registrados")
     public List<EmpleadoDto> all() {
         return svc.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Obtener por id", description = "Recupera un empleado por su identificador")
     public EmpleadoDto getById(@PathVariable Long id) {
         return svc.findById(id);
     }
 
     @GetMapping("/documento/{documento}")
+    @Operation(summary = "Buscar por documento", description = "Busca un empleado utilizando su documento")
     public EmpleadoDto getByDocumento(@PathVariable String documento) {
         return svc.findByDocumento(documento);
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Actualizar empleado", description = "Modifica los datos de un empleado existente")
     public EmpleadoDto update(@PathVariable Long id, @RequestBody EmpleadoDto dto) {
         return svc.update(id, dto);
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar empleado", description = "Elimina el empleado indicado")
     public void delete(@PathVariable Long id) {
         svc.delete(id);
     }

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/PuestoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/PuestoController.java
@@ -6,21 +6,26 @@ import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.PuestoDetalleDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/empleados/{empleadoId}/puestos")
 @RequiredArgsConstructor
+@Tag(name = "Puestos", description = "Gestión de puestos del empleado")
 public class PuestoController {
 
     private final PuestoService svc;
 
     @PostMapping
+    @Operation(summary = "Crear puesto", description = "Agrega un puesto al empleado")
     public PuestoDto create(@PathVariable Long empleadoId,
                             @RequestBody PuestoDto dto) {
         return svc.create(empleadoId, dto);
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Actualizar puesto", description = "Modifica un puesto del empleado")
     public PuestoDto update(@PathVariable Long empleadoId,
                             @PathVariable Long id,
                             @RequestBody PuestoDto dto) {
@@ -28,18 +33,21 @@ public class PuestoController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar puesto", description = "Quita un puesto del empleado")
     public void delete(@PathVariable Long empleadoId,
                        @PathVariable Long id) {
         svc.delete(empleadoId, id);
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de puesto", description = "Obtiene un puesto específico")
     public PuestoDetalleDto get(@PathVariable Long empleadoId,
                                 @PathVariable Long id) {
         return svc.get(empleadoId, id);
     }
 
     @GetMapping("/detalle")
+    @Operation(summary = "Puestos detallados", description = "Lista puestos del empleado con detalle")
     public Page<PuestoDetalleDto> allDetailed(@PathVariable Long empleadoId,
                                               @RequestParam(defaultValue = "0") Integer page,
                                               @RequestParam(defaultValue = "10") Integer size) {
@@ -47,6 +55,7 @@ public class PuestoController {
     }
 
     @GetMapping
+    @Operation(summary = "Listar puestos", description = "Devuelve los puestos asociados al empleado")
     public Page<PuestoDto> all(@PathVariable Long empleadoId,
                                @RequestParam(defaultValue = "0") Integer page,
                                @RequestParam(defaultValue = "10") Integer size) {

--- a/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/SindicatoController.java
+++ b/servicio-empleado/src/main/java/ar/org/hospitalcuencaalta/servicio_empleado/controlador/SindicatoController.java
@@ -6,21 +6,26 @@ import ar.org.hospitalcuencaalta.servicio_empleado.web.dto.SindicatoDetalleDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/empleados/{empleadoId}/sindicatos")
 @RequiredArgsConstructor
+@Tag(name = "Sindicatos", description = "Gestión de sindicatos del empleado")
 public class SindicatoController {
 
     private final SindicatoService svc;
 
     @PostMapping
+    @Operation(summary = "Crear sindicato", description = "Asocia un sindicato al empleado")
     public SindicatoDto create(@PathVariable Long empleadoId,
                                @RequestBody SindicatoDto dto) {
         return svc.create(empleadoId, dto);
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "Actualizar sindicato", description = "Modifica un sindicato del empleado")
     public SindicatoDto update(@PathVariable Long empleadoId,
                                @PathVariable Long id,
                                @RequestBody SindicatoDto dto) {
@@ -28,18 +33,21 @@ public class SindicatoController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar sindicato", description = "Quita el sindicato indicado")
     public void delete(@PathVariable Long empleadoId,
                        @PathVariable Long id) {
         svc.delete(empleadoId, id);
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de sindicato", description = "Obtiene datos de un sindicato")
     public SindicatoDetalleDto get(@PathVariable Long empleadoId,
                                    @PathVariable Long id) {
         return svc.get(empleadoId, id);
     }
 
     @GetMapping("/detalle")
+    @Operation(summary = "Sindicatos detallados", description = "Lista los sindicatos del empleado con detalle")
     public Page<SindicatoDetalleDto> allDetailed(@PathVariable Long empleadoId,
                                                  @RequestParam(defaultValue = "0") Integer page,
                                                  @RequestParam(defaultValue = "10") Integer size) {
@@ -47,6 +55,7 @@ public class SindicatoController {
     }
 
     @GetMapping
+    @Operation(summary = "Listar sindicatos", description = "Devuelve los sindicatos del empleado")
     public Page<SindicatoDto> all(@PathVariable Long empleadoId,
                                   @RequestParam(defaultValue = "0") Integer page,
                                   @RequestParam(defaultValue = "10") Integer size) {

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/config/EntrenamientoOpenApiConfig.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/config/EntrenamientoOpenApiConfig.java
@@ -1,0 +1,21 @@
+package ar.org.hospitalcuencaalta.servicio_entrenamiento.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de OpenAPI para el Servicio Entrenamiento.
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Servicio Entrenamiento",
+                version = "v1",
+                description = "Gestiona cursos y capacitaciones del personal.",
+                contact = @Contact(name = "Equipo RRHH", email = "rrhh@example.com")
+        )
+)
+public class EntrenamientoOpenApiConfig {
+}

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/CapacitacionController.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/CapacitacionController.java
@@ -5,24 +5,30 @@ import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.CapacitacionDeta
 import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.CapacitacionDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/capacitaciones")
+@Tag(name = "Capacitaciones", description = "Gestión de capacitaciones")
 public class CapacitacionController {
     @Autowired
     private CapacitacionService svc;
 
     @PostMapping
+    @Operation(summary = "Crear capacitación", description = "Registra una nueva capacitación")
     public CapacitacionDto create(@RequestBody CapacitacionDto dto) {
         return svc.create(dto);
     }
     @GetMapping
+    @Operation(summary = "Listar capacitaciones", description = "Obtiene todas las capacitaciones")
     public List<CapacitacionDto> all() {
         return svc.findAll();
     }
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de capacitación", description = "Obtiene información detallada")
     public CapacitacionDetalleDto get(@PathVariable Long id) {
         return svc.getDetalle(id);
     }

--- a/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/EvaluacionController.java
+++ b/servicio-entrenamiento/src/main/java/ar/org/hospitalcuencaalta/servicio_entrenamiento/controlador/EvaluacionController.java
@@ -5,24 +5,30 @@ import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EvaluacionDetall
 import ar.org.hospitalcuencaalta.servicio_entrenamiento.web.dto.EvaluacionDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/evaluaciones")
+@Tag(name = "Evaluaciones", description = "Gestión de evaluaciones")
 public class EvaluacionController {
     @Autowired
     private EvaluacionService svc;
 
     @PostMapping
+    @Operation(summary = "Crear evaluación", description = "Registra una evaluación de capacitación")
     public EvaluacionDto create(@RequestBody EvaluacionDto dto) {
         return svc.create(dto);
     }
     @GetMapping
+    @Operation(summary = "Listar evaluaciones", description = "Muestra todas las evaluaciones registradas")
     public List<EvaluacionDto> all() {
         return svc.findAll();
     }
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de evaluación", description = "Obtiene los detalles de una evaluación")
     public EvaluacionDetalleDto get(@PathVariable Long id) {
         return svc.getDetalle(id);
     }

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/config/NominaOpenApiConfig.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/config/NominaOpenApiConfig.java
@@ -1,0 +1,21 @@
+package ar.org.hospitalcuencaalta.servicio_nomina.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de OpenAPI para el Servicio Nómina.
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Servicio Nómina",
+                version = "v1",
+                description = "Procesa pagos y recibos salariales.",
+                contact = @Contact(name = "Equipo RRHH", email = "rrhh@example.com")
+        )
+)
+public class NominaOpenApiConfig {
+}

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/ConceptoLiquidacionController.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/ConceptoLiquidacionController.java
@@ -5,26 +5,32 @@ import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.ConceptoLiquidacionDeta
 import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.ConceptoLiquidacionDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/conceptos")
+@Tag(name = "Conceptos", description = "Administración de conceptos de liquidación")
 public class ConceptoLiquidacionController {
     @Autowired
     private ConceptoLiquidacionService svc;
 
     @PostMapping
+    @Operation(summary = "Crear concepto", description = "Registra un concepto de liquidación")
     public ConceptoLiquidacionDto create(@RequestBody ConceptoLiquidacionDto dto) {
         return svc.create(dto);
     }
 
     @GetMapping
+    @Operation(summary = "Listar conceptos", description = "Obtiene todos los conceptos disponibles")
     public List<ConceptoLiquidacionDto> all() {
         return svc.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de concepto", description = "Devuelve un concepto específico")
     public ConceptoLiquidacionDetalleDto get(@PathVariable Long id) {
         return svc.getDetalle(id);
     }

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/EmpleadoConceptoController.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/EmpleadoConceptoController.java
@@ -7,14 +7,18 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/empleados/{empleadoId}/conceptos")
+@Tag(name = "Conceptos de Empleado", description = "Asignación de conceptos a empleados")
 public class EmpleadoConceptoController {
     @Autowired
     private EmpleadoConceptoService svc;
 
     @PostMapping("/{conceptoId}")
+    @Operation(summary = "Asignar concepto", description = "Vincula un concepto de liquidación al empleado")
     public EmpleadoConceptoDto asignar(@PathVariable Long empleadoId, @PathVariable Long conceptoId) {
         return svc.asignarConcepto(empleadoId, conceptoId);
     }

--- a/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/LiquidacionController.java
+++ b/servicio-nomina/src/main/java/ar/org/hospitalcuencaalta/servicio_nomina/controlador/LiquidacionController.java
@@ -5,31 +5,38 @@ import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.LiquidacionDetalleDto;
 import ar.org.hospitalcuencaalta.servicio_nomina.web.dto.LiquidacionDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/liquidaciones")
+@Tag(name = "Liquidaciones", description = "Procesos de liquidación de salarios")
 public class LiquidacionController {
     @Autowired
     private LiquidacionService svc;
 
     @PostMapping
+    @Operation(summary = "Crear liquidación", description = "Genera una nueva liquidación")
     public LiquidacionDto create(@RequestBody LiquidacionDto dto) {
         return svc.create(dto);
     }
 
     @GetMapping
+    @Operation(summary = "Listar liquidaciones", description = "Obtiene todas las liquidaciones")
     public List<LiquidacionDto> all() {
         return svc.findAll();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Detalle de liquidación", description = "Devuelve la liquidación indicada")
     public LiquidacionDetalleDto get(@PathVariable Long id) {
         return svc.getDetalle(id);
     }
 
     @PostMapping("/{id}/calcular")
+    @Operation(summary = "Calcular nómina", description = "Procesa la liquidación de un periodo")
     public LiquidacionDetalleDto calcular(@PathVariable Long id) {
         return svc.calcularNomina(id);
     }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/OrquestadorOpenApiConfig.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/config/OrquestadorOpenApiConfig.java
@@ -1,0 +1,21 @@
+package ar.org.hospitalcuencaalta.servicio_orquestador.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuración de OpenAPI para el Servicio Orquestador.
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Servicio Orquestador",
+                version = "v1",
+                description = "Coordina la creación y actualización de empleados y contratos mediante SAGA.",
+                contact = @Contact(name = "Equipo RRHH", email = "rrhh@example.com")
+        )
+)
+public class OrquestadorOpenApiConfig {
+}

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/CircuitBreakerStatusController.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/CircuitBreakerStatusController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -20,6 +22,7 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/actuator/cb-state")
+@Tag(name = "Circuit Breaker", description = "Estado de los disyuntores del sistema")
 public class CircuitBreakerStatusController {
 
     private final CircuitBreakerRegistry registry;
@@ -32,6 +35,7 @@ public class CircuitBreakerStatusController {
     }
 
     @GetMapping("/{name}")
+    @Operation(summary = "Estado de breaker", description = "Obtiene el estado de un circuit breaker")
     public ResponseEntity<Map<String, Object>> getState(@PathVariable String name,
                                                         @RequestParam(defaultValue = "false") boolean includeState) {
         CircuitBreaker cb = registry.getAllCircuitBreakers()
@@ -51,6 +55,7 @@ public class CircuitBreakerStatusController {
     }
 
     @GetMapping("/empleado-actions")
+    @Operation(summary = "Historial de empleados", description = "Acciones realizadas sobre empleados")
     public ResponseEntity<java.util.List<CreationAction>> allActions() {
         return ResponseEntity.ok(history.creationAttempts());
     }

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaController.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaController.java
@@ -16,6 +16,8 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import reactor.core.publisher.Flux;
 
 import java.time.Instant;
@@ -27,6 +29,7 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api/saga")
+@Tag(name = "SAGA Empleado-Contrato", description = "Orquestación de empleados y contratos")
 public class SagaController {
 
     private final StateMachineFactory<Estados, Eventos> stateMachineFactory;
@@ -63,6 +66,7 @@ public class SagaController {
     }
 
     @PostMapping("/empleado-contrato")
+    @Operation(summary = "Iniciar SAGA", description = "Comienza la orquestación de creación de empleado y contrato")
     public ResponseEntity<SagaStatusResponse> iniciarSaga(@RequestBody SagaEmpleadoContratoRequest request) {
         // 1) Crear un nuevo StateMachine de SAGA por cada petición
         StateMachine<Estados, Eventos> stateMachine =
@@ -123,6 +127,7 @@ public class SagaController {
     }
 
     @PutMapping("/empleado-contrato/{id}")
+    @Operation(summary = "Actualizar SAGA", description = "Modifica empleado y contrato de forma coordinada")
     public SagaStatusResponse actualizarSaga(@PathVariable("id") Long id,
                                              @RequestBody SagaEmpleadoContratoRequest request) {
         StateMachine<Estados, Eventos> stateMachine = stateMachineFactory.getStateMachine();
@@ -197,6 +202,7 @@ public class SagaController {
     }
 
     @DeleteMapping("/empleado-contrato/{id}")
+    @Operation(summary = "Eliminar SAGA", description = "Elimina empleado y contrato mediante orquestación")
     public SagaStatusResponse eliminarSaga(@PathVariable("id") Long id,
                                             @RequestParam("contratoId") Long contratoId) {
         StateMachine<Estados, Eventos> stateMachine = stateMachineFactory.getStateMachine();
@@ -241,7 +247,7 @@ public class SagaController {
     }
 
     @GetMapping("/empleado-contrato/{id}")
-
+    @Operation(summary = "Estado de SAGA", description = "Obtiene el estado actual de la SAGA")
     public ResponseEntity<SagaStatusResponse> obtenerEstado(@PathVariable("id") Long id) {
 
 

--- a/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaOperationController.java
+++ b/servicio-orquestador/src/main/java/ar/org/hospitalcuencaalta/servicio_orquestador/controlador/SagaOperationController.java
@@ -3,11 +3,14 @@ package ar.org.hospitalcuencaalta.servicio_orquestador.controlador;
 import ar.org.hospitalcuencaalta.servicio_orquestador.operacion.SagaOperation;
 import ar.org.hospitalcuencaalta.servicio_orquestador.servicio.SagaOperationService;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/saga/operaciones")
+@Tag(name = "Operaciones de SAGA", description = "Historial de pasos ejecutados")
 public class SagaOperationController {
 
     private final SagaOperationService service;
@@ -17,6 +20,7 @@ public class SagaOperationController {
     }
 
     @GetMapping
+    @Operation(summary = "Historial", description = "Listado de operaciones realizadas por una SAGA")
     public List<SagaOperation> all(@RequestParam(value = "sagaId", required = false) Long sagaId) {
         if (sagaId != null) {
             return service.findBySagaId(sagaId);


### PR DESCRIPTION
## Summary
- add OpenAPI config classes for each service
- document endpoints using `@Tag` and `@Operation`
- keep gateway and other infrastructure modules unchanged

## Testing
- `./mvnw -q -DskipTests verify` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687104952b808324a5f75911d7129a30