### PR TITLE
Ignore SSE disconnect stack traces

### DIFF
--- a/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/logging/IgnoreClientAbortExceptionFilter.java
+++ b/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/logging/IgnoreClientAbortExceptionFilter.java
@@ -1,0 +1,29 @@
+package ar.org.hospitalcuencaalta.servidor_para_monitoreo.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+/**
+ * Filtro para ignorar excepciones causadas por cierres prematuros de la conexi\u00f3n
+ * ("Broken pipe" o "Connection reset by peer"). Estas excepciones suelen
+ * producirse cuando el cliente cancela la suscripci\u00f3n SSE y no representan un
+ * fallo real del servidor.
+ */
+public class IgnoreClientAbortExceptionFilter extends Filter<ILoggingEvent> {
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        if (event == null) {
+            return FilterReply.NEUTRAL;
+        }
+        if (event.getThrowableProxy() != null) {
+            String msg = event.getThrowableProxy().getMessage();
+            if (msg != null && (msg.contains("Se ha anulado una conexi\u00f3n")
+                    || msg.contains("Broken pipe")
+                    || msg.contains("Connection reset by peer"))) {
+                return FilterReply.DENY;
+            }
+        }
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/servidor-para-monitoreo/src/main/resources/logback-spring.xml
+++ b/servidor-para-monitoreo/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<configuration>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ar.org.hospitalcuencaalta.servidor_para_monitoreo.logging.IgnoreClientAbortExceptionFilter"/>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ar.org.hospitalcuencaalta.servidor_para_monitoreo.logging.IgnoreClientAbortExceptionFilter"/>
+        <file>logs/servidor-para-monitoreo.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/servidor-para-monitoreo.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add filter to ignore client abort exceptions
- configure logback for monitor server to use the new filter

## Testing
- `./mvnw -q -pl servidor-para-monitoreo test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68727abec04c832494d4b486b447d407