### PR TITLE
Improve monitoring dashboard

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -290,3 +290,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.api_gateway
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-consultas/src/main/resources/application.properties
+++ b/servicio-consultas/src/main/resources/application.properties
@@ -39,3 +39,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_consultas.controla
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -40,3 +40,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_contrato.controlad
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -64,3 +64,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_empleado.controlad
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -47,3 +47,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_entrenamiento.cont
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -51,3 +51,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_nomina.controlador
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-openapi-ui/src/main/resources/application.properties
+++ b/servicio-openapi-ui/src/main/resources/application.properties
@@ -7,3 +7,4 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -164,3 +164,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_orquestador.contro
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -28,3 +28,4 @@ eureka.server.renewal-percent-threshold=0.49
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html

--- a/servidor-para-monitoreo/README.adoc
+++ b/servidor-para-monitoreo/README.adoc
@@ -19,7 +19,7 @@ Eureka para evitar registros duplicados en la consola de administración.
 == Interfaz personalizada
 
 Además de la consola de administración de Spring Boot Admin, este módulo incluye un tablero liviano en `http://localhost:9090/dashboard/`.
-Ahora se muestran también el consumo de CPU, memoria y espacio en disco de cada servicio. Los valores aparecen como indicadores circulares y gráficos simples que se actualizan de forma manual con el botón *Refrescar*. Chart.js se incluye localmente para no depender de Internet. Se añadió una página de ayuda accesible en `http://localhost:9090/dashboard/ayuda.html` que explica cómo interpretar cada dato del tablero.
+Ahora se muestran también el consumo de CPU, memoria y espacio en disco de cada servicio. Los valores se presentan mediante barras de progreso y gráficos simples que se actualizan de forma manual con el botón *Refrescar*. Chart.js se incluye localmente para no depender de Internet. Se añadió una página de ayuda accesible en `http://localhost:9090/dashboard/ayuda.html` que explica cómo interpretar cada dato del tablero. Además podés hacer clic en el nombre de un servicio para ver un resumen detallado en `detalle.html`.
 
 == Detalles de implementación
 

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/ayuda.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/ayuda.html
@@ -20,13 +20,16 @@
             <li><strong>Nombre</strong>: identificador legible del servicio.</li>
             <li><strong>Estado</strong>: valor reportado por Actuator (por ejemplo, <em>UP</em> o <em>DOWN</em>).</li>
             <li><strong>Versión</strong>: versión de la aplicación obtenida de los metadatos de registro.</li>
-            <li><strong>CPU</strong>: porcentaje de uso del CPU del servidor donde se ejecuta el servicio.</li>
-            <li><strong>Memoria</strong>: porcentaje de heap utilizado según las métricas de la JVM.</li>
+            <li><strong>CPU</strong>: barra de progreso con el porcentaje de uso del CPU del servidor donde se ejecuta el servicio.</li>
+            <li><strong>Memoria</strong>: barra de progreso con el porcentaje de heap utilizado según las métricas de la JVM.</li>
+            <li><strong>Disco</strong>: barra de progreso con el porcentaje de espacio utilizado en el disco.</li>
             <li><strong>Última Actualización</strong>: fecha y hora del último cambio de estado informado.</li>
         </ul>
 
         <h2 class="subtitle">Gráfico de estados</h2>
         <p>Debajo de la tabla se muestra un gráfico de barras con la cantidad de servicios por estado. Sirve para obtener una vista rápida de cuántos servicios están activos o presentan problemas.</p>
+
+        <p>Si hacés clic en el nombre de un servicio accederás a una página con un resumen de la instancia y un enlace directo a su documentación OpenAPI.</p>
 
         <h2 class="subtitle">Consejos adicionales</h2>
         <p>Al explorar cada instancia desde la consola principal de Spring Boot Admin podrás acceder a métricas detalladas, trazas y logs. Este tablero ofrece un resumen liviano para seguimiento diario.</p>

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/detalle.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/detalle.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Detalle del Servicio</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.4/css/bulma.min.css">
+</head>
+<body onload="loadDetail()">
+<section class="section">
+    <div class="container">
+        <h1 id="title" class="title"></h1>
+        <p class="subtitle" id="status"></p>
+        <p>Versión: <span id="version"></span></p>
+        <p id="link"></p>
+        <div class="mt-4">
+            <p>CPU</p>
+            <div id="cpu"></div>
+        </div>
+        <div class="mt-4">
+            <p>Memoria</p>
+            <div id="mem"></div>
+        </div>
+        <div class="mt-4">
+            <p>Disco</p>
+            <div id="disk"></div>
+        </div>
+        <p class="mt-4">Última actualización: <span id="update"></span></p>
+        <a class="button is-link mt-5" href="index.html">Volver</a>
+    </div>
+</section>
+<script>
+function progressBar(value, colorClass) {
+    return `<progress class="progress ${colorClass}" value="${value}" max="100">${value}%</progress>`;
+}
+async function loadDetail() {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (!id) return;
+    const instanceRes = await fetch(`/instances/${id}`);
+    if (!instanceRes.ok) return;
+    const instance = await instanceRes.json();
+    document.getElementById('title').innerText = instance.registration?.name || id;
+    document.getElementById('status').innerText = `Estado: ${instance.status}`;
+    document.getElementById('version').innerText = instance.registration?.metadata?.buildVersion || 'N/A';
+    const url = instance.registration?.serviceUrl;
+    if (url) {
+        document.getElementById('link').innerHTML = `<a href="${url}" target="_blank">Abrir documentación</a>`;
+    }
+    const [cpuData, memUsedData, memMaxData, diskFreeData, diskTotalData] = await Promise.all([
+        fetch(`/instances/${id}/actuator/metrics/system.cpu.usage`).then(r => r.ok ? r.json() : null),
+        fetch(`/instances/${id}/actuator/metrics/jvm.memory.used?tag=area:heap`).then(r => r.ok ? r.json() : null),
+        fetch(`/instances/${id}/actuator/metrics/jvm.memory.max?tag=area:heap`).then(r => r.ok ? r.json() : null),
+        fetch(`/instances/${id}/actuator/metrics/disk.free`).then(r => r.ok ? r.json() : null),
+        fetch(`/instances/${id}/actuator/metrics/disk.total`).then(r => r.ok ? r.json() : null)
+    ]);
+    const cpu = cpuData?.measurements?.[0]?.value ? (cpuData.measurements[0].value * 100).toFixed(1) : 'N/A';
+    const memUsed = memUsedData?.measurements?.[0]?.value || 0;
+    const memMax = memMaxData?.measurements?.[0]?.value || 0;
+    const memPercent = memMax > 0 ? ((memUsed / memMax) * 100).toFixed(1) : 'N/A';
+    const diskFree = diskFreeData?.measurements?.[0]?.value || 0;
+    const diskTotal = diskTotalData?.measurements?.[0]?.value || 0;
+    const diskPercent = diskTotal > 0 ? (((diskTotal - diskFree) / diskTotal) * 100).toFixed(1) : 'N/A';
+    if (cpu !== 'N/A') document.getElementById('cpu').innerHTML = progressBar(cpu, 'is-info');
+    else document.getElementById('cpu').innerText = 'N/A';
+    if (memPercent !== 'N/A') document.getElementById('mem').innerHTML = progressBar(memPercent, 'is-warning');
+    else document.getElementById('mem').innerText = 'N/A';
+    if (diskPercent !== 'N/A') document.getElementById('disk').innerHTML = progressBar(diskPercent, 'is-danger');
+    else document.getElementById('disk').innerText = 'N/A';
+    document.getElementById('update').innerText = instance.statusTimestamp ? new Date(instance.statusTimestamp).toLocaleString() : 'N/A';
+}
+</script>
+</body>
+</html>

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/index.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/index.html
@@ -43,22 +43,8 @@
     </div>
 </section>
 <script>
-function renderGauge(id, value, color) {
-    new Chart(document.getElementById(id), {
-        type: "doughnut",
-        data: {
-            datasets: [{
-                data: [value, 100 - value],
-                backgroundColor: [color, "#f5f5f5"],
-                borderWidth: 0
-            }]
-        },
-        options: {
-            cutout: "70%",
-            responsive: false,
-            plugins: { tooltip: { enabled: false }, legend: { display: false } }
-        }
-    });
+function progressBar(value, colorClass) {
+    return `<progress class="progress ${colorClass}" value="${value}" max="100">${value}%</progress>`;
 }
 
 async function loadServices() {
@@ -99,26 +85,21 @@ async function loadServices() {
             const diskTotal = diskTotalData?.measurements?.[0]?.value || 0;
             const diskPercent = diskTotal > 0 ? (((diskTotal - diskFree) / diskTotal) * 100).toFixed(1) : 'N/A';
 
+            const nameLink = `<a href="detalle.html?id=${instance.id}">${name}</a>`;
             const update = instance.statusTimestamp ? new Date(instance.statusTimestamp).toLocaleString() : 'N/A';
             nameArray.push(name);
             memArray.push(memPercent === 'N/A' ? 0 : parseFloat(memPercent));
             diskArray.push(diskPercent === 'N/A' ? 0 : parseFloat(diskPercent));
-            const cpuId = `cpu-${instance.id}`;
-            const memId = `mem-${instance.id}`;
-            const diskId = `disk-${instance.id}`;
-            const cpuCell = cpu === "N/A" ? "N/A" : `<canvas id="${cpuId}" width="60" height="60"></canvas><small>${cpu}%</small>`;
-            const memCell = memPercent === "N/A" ? "N/A" : `<canvas id="${memId}" width="60" height="60"></canvas><small>${memPercent}%</small>`;
-            const diskCell = diskPercent === "N/A" ? "N/A" : `<canvas id="${diskId}" width="60" height="60"></canvas><small>${diskPercent}%</small>`;
+            const cpuCell = cpu === "N/A" ? "N/A" : progressBar(cpu, 'is-info');
+            const memCell = memPercent === "N/A" ? "N/A" : progressBar(memPercent, 'is-warning');
+            const diskCell = diskPercent === "N/A" ? "N/A" : progressBar(diskPercent, 'is-danger');
 
-            tr.innerHTML = `<td>${name}</td><td>${status}</td><td>${version}</td>` +
+            tr.innerHTML = `<td>${nameLink}</td><td>${status}</td><td>${version}</td>` +
                 `<td>${cpuCell}</td>` +
                 `<td>${memCell}</td>` +
                 `<td>${diskCell}</td>` +
                 `<td>${update}</td>`;
             tbody.appendChild(tr);
-            if(cpu !== "N/A") renderGauge(cpuId, parseFloat(cpu), "rgba(54, 162, 235, 0.8)");
-            if(memPercent !== "N/A") renderGauge(memId, parseFloat(memPercent), "rgba(255, 159, 64, 0.8)");
-            if(diskPercent !== "N/A") renderGauge(diskId, parseFloat(diskPercent), "rgba(255, 99, 132, 0.8)");
         }
 
         // Graficar estados


### PR DESCRIPTION
## Summary
- show metrics with Bulma progress bars instead of gauges
- link service names to a new `detalle.html` page with detailed metrics
- document dashboard improvements in README and help page
- expose Swagger UI links in Spring Boot Admin via `service-url`

## Testing
- `./mvnw -q test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68727db33fd88324abfbe2489fe3fa77