### PR TITLE
Fix monitoring registration via Boot Admin

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -290,4 +290,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.api_gateway
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-consultas/src/main/resources/application.properties
+++ b/servicio-consultas/src/main/resources/application.properties
@@ -39,4 +39,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_consultas.controla
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -40,4 +40,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_contrato.controlad
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -64,4 +64,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_empleado.controlad
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -47,4 +47,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_entrenamiento.cont
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -51,4 +51,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_nomina.controlador
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-openapi-ui/src/main/resources/application.properties
+++ b/servicio-openapi-ui/src/main/resources/application.properties
@@ -7,4 +7,4 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -164,4 +164,4 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_orquestador.contro
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -28,4 +28,4 @@ eureka.server.renewal-percent-threshold=0.49
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
-spring.boot.admin.client.instance.service-url=http://localhost:${server.port}/swagger-ui.html
+spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/detalle.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/detalle.html
@@ -43,7 +43,7 @@ async function loadDetail() {
     document.getElementById('title').innerText = instance.registration?.name || id;
     document.getElementById('status').innerText = `Estado: ${instance.status}`;
     document.getElementById('version').innerText = instance.registration?.metadata?.buildVersion || 'N/A';
-    const url = instance.registration?.serviceUrl;
+    const url = instance.registration?.metadata?.swaggerUrl || instance.registration?.serviceUrl;
     if (url) {
         document.getElementById('link').innerHTML = `<a href="${url}" target="_blank">Abrir documentación</a>`;
     }


### PR DESCRIPTION
## Summary
- revert Boot Admin `service-url` to avoid wrong actuator base URL
- expose Swagger link using metadata for all services
- update monitoring dashboard to read new metadata field

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68728314f0c88324a9fc479324de001c