### PR TITLE
Add microservice control page

### DIFF
--- a/servidor-para-monitoreo/README.adoc
+++ b/servidor-para-monitoreo/README.adoc
@@ -30,6 +30,7 @@ management.metrics.binders.files.enabled=true
 
 Además de la consola de administración de Spring Boot Admin, este módulo incluye un tablero liviano en `http://localhost:9090/dashboard/`.
 Ahora se muestran también el consumo de CPU, memoria y espacio en disco de cada servicio. Los valores se presentan mediante barras de progreso y gráficos simples que se actualizan de forma manual con el botón *Refrescar*. Chart.js se incluye localmente para no depender de Internet. Se añadió una página de ayuda accesible en `http://localhost:9090/dashboard/ayuda.html` que explica cómo interpretar cada dato del tablero. Además podés hacer clic en el nombre de un servicio para ver un resumen detallado en `detalle.html`.
+También se añadió `http://localhost:9090/dashboard/gestion.html` para iniciar o detener manualmente los servicios.
 
 == Detalles de implementación
 

--- a/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/controller/MicroserviceControlController.java
+++ b/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/controller/MicroserviceControlController.java
@@ -1,0 +1,42 @@
+package ar.org.hospitalcuencaalta.servidor_para_monitoreo.controller;
+
+import ar.org.hospitalcuencaalta.servidor_para_monitoreo.service.MicroserviceManager;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/control")
+@RequiredArgsConstructor
+@Tag(name = "Control de servicios", description = "Iniciar y detener microservicios")
+public class MicroserviceControlController {
+
+    private final MicroserviceManager manager;
+
+    @PostMapping("/start")
+    @Operation(summary = "Iniciar servicio", description = "Inicia N instancias del microservicio")
+    public ResponseEntity<Map<String, Integer>> start(@RequestBody ControlRequest req) throws IOException {
+        manager.start(req.service(), req.count());
+        return ResponseEntity.ok(manager.status());
+    }
+
+    @PostMapping("/stop")
+    @Operation(summary = "Detener servicio", description = "Detiene N instancias del microservicio")
+    public ResponseEntity<Map<String, Integer>> stop(@RequestBody ControlRequest req) {
+        manager.stop(req.service(), req.count());
+        return ResponseEntity.ok(manager.status());
+    }
+
+    @GetMapping("/status")
+    @Operation(summary = "Estado de servicios", description = "Cantidad de instancias en ejecución por servicio")
+    public Map<String, Integer> status() {
+        return manager.status();
+    }
+
+    public record ControlRequest(String service, int count) {}
+}

--- a/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/service/MicroserviceManager.java
+++ b/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/service/MicroserviceManager.java
@@ -1,0 +1,57 @@
+package ar.org.hospitalcuencaalta.servidor_para_monitoreo.service;
+
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class MicroserviceManager {
+    private final Map<String, String> serviceDirs;
+    private final Map<String, List<Process>> processes = new ConcurrentHashMap<>();
+
+    public MicroserviceManager() {
+        serviceDirs = Map.ofEntries(
+            Map.entry("servicio-contrato", "../../servicio-contrato"),
+            Map.entry("servicio-empleado", "../../servicio-empleado"),
+            Map.entry("servicio-entrenamiento", "../../servicio-entrenamiento"),
+            Map.entry("servicio-nomina", "../../servicio-nomina"),
+            Map.entry("servicio-orquestador", "../../servicio-orquestador"),
+            Map.entry("servicio-consultas", "../../servicio-consultas"),
+            Map.entry("API-gateway", "../../API-gateway"),
+            Map.entry("servidor-para-descubrimiento", "../../servidor-para-descubrimiento")
+        );
+    }
+
+    public synchronized void start(String name, int count) throws IOException {
+        String dir = serviceDirs.get(name);
+        if (dir == null) {
+            throw new IllegalArgumentException("Servicio desconocido: " + name);
+        }
+        for (int i = 0; i < count; i++) {
+            ProcessBuilder pb = new ProcessBuilder("./mvnw", "spring-boot:run");
+            pb.directory(new File(dir));
+            pb.inheritIO();
+            Process p = pb.start();
+            processes.computeIfAbsent(name, k -> new ArrayList<>()).add(p);
+        }
+    }
+
+    public synchronized void stop(String name, int count) {
+        List<Process> list = processes.getOrDefault(name, Collections.emptyList());
+        for (int i = 0; i < count && !list.isEmpty(); i++) {
+            Process p = list.remove(list.size() - 1);
+            p.destroy();
+        }
+    }
+
+    public synchronized Map<String, Integer> status() {
+        Map<String, Integer> status = new LinkedHashMap<>();
+        for (String key : serviceDirs.keySet()) {
+            status.put(key, processes.getOrDefault(key, Collections.emptyList()).size());
+        }
+        return status;
+    }
+}

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/gestion.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/gestion.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestión de Servicios</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.4/css/bulma.min.css">
+</head>
+<body onload="loadStatus()">
+<section class="section">
+    <div class="container">
+        <h1 class="title">Gestión de Servicios</h1>
+        <p class="subtitle">Iniciar o detener instancias de microservicios</p>
+        <div class="mb-4">
+            <a class="button is-light" href="index.html">Volver</a>
+        </div>
+        <table class="table is-fullwidth">
+            <thead>
+            <tr>
+                <th>Servicio</th>
+                <th>Instancias en ejecución</th>
+                <th>Acciones</th>
+            </tr>
+            </thead>
+            <tbody id="services-body"></tbody>
+        </table>
+    </div>
+</section>
+<script>
+async function loadStatus() {
+    const res = await fetch('/control/status');
+    const data = await res.json();
+    const tbody = document.getElementById('services-body');
+    tbody.innerHTML = '';
+    for (const [name, count] of Object.entries(data)) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${name}</td>
+            <td id="count-${name}">${count}</td>
+            <td>
+                <input id="num-${name}" class="input is-small" type="number" min="1" value="1" style="width:70px; display:inline">
+                <button class="button is-small is-success" onclick="startSvc('${name}')">Iniciar</button>
+                <button class="button is-small is-danger" onclick="stopSvc('${name}')">Detener</button>
+            </td>`;
+        tbody.appendChild(tr);
+    }
+}
+async function startSvc(name) {
+    const num = parseInt(document.getElementById('num-' + name).value || '1', 10);
+    await fetch('/control/start', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({service: name, count: num})
+    });
+    loadStatus();
+}
+async function stopSvc(name) {
+    const num = parseInt(document.getElementById('num-' + name).value || '1', 10);
+    await fetch('/control/stop', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({service: name, count: num})
+    });
+    loadStatus();
+}
+</script>
+</body>
+</html>

--- a/servidor-para-monitoreo/src/main/resources/static/dashboard/index.html
+++ b/servidor-para-monitoreo/src/main/resources/static/dashboard/index.html
@@ -15,6 +15,7 @@
         <div class="mb-4">
             <button class="button is-link" onclick="loadServices()">Refrescar</button>
             <a class="button is-light" href="ayuda.html">Ayuda</a>
+            <a class="button is-light" href="gestion.html">Gestión</a>
         </div>
         <div id="global-metrics" class="columns is-multiline mb-5">
             <div class="column is-one-third has-text-centered">


### PR DESCRIPTION
## Summary
- add `MicroserviceManager` service to launch/stop modules via Maven
- provide `MicroserviceControlController` REST API
- include new dashboard page `gestion.html` with start/stop controls
- link control page from index
- document the new feature in README

## Testing
- `./mvnw -pl servidor-para-monitoreo test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6872a923f62c8324b4004e2dd9107ee4