### PR TITLE
Improve service control links

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/GatewayConfig.java
@@ -32,6 +32,9 @@ public class GatewayConfig {
                 .route("saga_route", r -> r.path("/api/saga/**")
                         .filters(f -> f.dedupeResponseHeader("Access-Control-Allow-Origin", "RETAIN_UNIQUE"))
                         .uri("lb://servicio-orquestador"))
+                .route("discovery_docs", r -> r.path("/servidor-para-descubrimiento/v3/api-docs")
+                        .filters(f -> f.stripPrefix(1).dedupeResponseHeader("Access-Control-Allow-Origin", "RETAIN_UNIQUE"))
+                        .uri("http://localhost:8761"))
                 .route("discovery_route", r -> r.path("/servidor-para-descubrimiento/**")
                         .filters(f -> f.stripPrefix(1)
                                 .dedupeResponseHeader("Access-Control-Allow-Origin", "RETAIN_UNIQUE"))
@@ -58,9 +61,6 @@ public class GatewayConfig {
                 .route("orquestador_docs", r -> r.path("/servicio-orquestador/v3/api-docs")
                         .filters(f -> f.stripPrefix(1).dedupeResponseHeader("Access-Control-Allow-Origin", "RETAIN_UNIQUE"))
                         .uri("lb://servicio-orquestador"))
-                .route("discovery_docs", r -> r.path("/servidor-para-descubrimiento/v3/api-docs")
-                        .filters(f -> f.stripPrefix(1).dedupeResponseHeader("Access-Control-Allow-Origin", "RETAIN_UNIQUE"))
-                        .uri("http://localhost:8761"))
                 .build();
     }
 }

--- a/servicio-openapi-ui/README.adoc
+++ b/servicio-openapi-ui/README.adoc
@@ -8,6 +8,8 @@ Forma parte del proyecto de microservicios de RRHH. Consultá `../README.adoc` p
 
 Levantá el servicio y accedé a `http://localhost:8085`.
 Seleccioná el microservicio deseado en el menú desplegable para visualizar su documentación.
+Desde la barra de navegación también podés ir al tablero de monitoreo en `http://localhost:9090/dashboard/gestion.html`
+para iniciar o detener instancias, o abrir la consola de Eureka en `http://localhost:8761`.
 
 Todos los microservicios deben estar en ejecución para que sus especificaciones
 estén disponibles. De lo contrario, el visor mostrará un mensaje de error.

--- a/servicio-openapi-ui/src/main/resources/static/microservicios.html
+++ b/servicio-openapi-ui/src/main/resources/static/microservicios.html
@@ -14,7 +14,15 @@
 <body>
   <header style="display:flex;justify-content:space-between;align-items:center;">
     <h1>Documentación OpenAPI de RRHH</h1>
-    <a id="link-indice" href="index.html" style="color: white"><strong>Volver</strong></a>
+    <nav>
+      <a id="link-indice" href="index.html" style="color: white;margin-right:1em;"><strong>Volver</strong></a>
+      <a href="http://localhost:9090/dashboard/gestion.html" style="color: white;margin-right:1em;">
+        <strong>Gestión de servicios</strong>
+      </a>
+      <a href="http://localhost:8761" style="color: white">
+        <strong>Consola Eureka</strong>
+      </a>
+    </nav>
   </header>
   <div id="selector">
     <label for="service-select">Servicio:</label>


### PR DESCRIPTION
## Summary
- expose link to service dashboard and Eureka console in microservice docs
- document the new links in README
- ensure gateway routes discovery docs correctly

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6873953cf2b083249000c25783d69af5