### PR TITLE
Improve monitoring handling

### DIFF
--- a/API-gateway/pom.xml
+++ b/API-gateway/pom.xml
@@ -68,6 +68,10 @@
             <groupId>de.codecentric</groupId>
             <artifactId>spring-boot-admin-starter-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ar.org.hospitalcuencaalta</groupId>
+            <artifactId>comunes</artifactId>
+        </dependency>
     </dependencies>
 
 <!--    <build>-->

--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -296,3 +296,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/controller/RootController.java
+++ b/comunes/src/main/java/ar/org/hospitalcuencaalta/comunes/controller/RootController.java
@@ -1,0 +1,24 @@
+package ar.org.hospitalcuencaalta.comunes.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controlador simple para responder en la raíz de cada microservicio.
+ * Evita que se muestre la página Whitelabel Error Page cuando se accede
+ * directamente al servicio desde Spring Boot Admin.
+ */
+@RestController
+public class RootController {
+
+    @Value("${spring.application.name:application}")
+    private String appName;
+
+    @GetMapping(value = "/", produces = MediaType.TEXT_HTML_VALUE)
+    public String index() {
+        return "<!DOCTYPE html><html><body><h1>" + appName +
+               "</h1><p>Servicio en funcionamiento.</p></body></html>";
+    }
+}

--- a/servicio-consultas/src/main/resources/application.properties
+++ b/servicio-consultas/src/main/resources/application.properties
@@ -44,3 +44,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -45,3 +45,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -69,3 +69,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -52,3 +52,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -56,3 +56,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servicio-openapi-ui/src/main/resources/application.properties
+++ b/servicio-openapi-ui/src/main/resources/application.properties
@@ -12,3 +12,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -165,3 +165,5 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_orquestador.contro
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR

--- a/servidor-para-descubrimiento/pom.xml
+++ b/servidor-para-descubrimiento/pom.xml
@@ -121,6 +121,10 @@
             <artifactId>spring-boot-admin-starter-client</artifactId>
             <version>3.2.2</version>
         </dependency>
+        <dependency>
+            <groupId>ar.org.hospitalcuencaalta</groupId>
+            <artifactId>comunes</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -33,3 +33,5 @@ spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server
 # Exponer métricas para el monitoreo
 management.endpoints.web.exposure.include=health,info,metrics
 management.metrics.binders.files.enabled=true
+
+logging.level.de.codecentric.boot.admin.client.registration=ERROR


### PR DESCRIPTION
## Summary
- add a global `RootController` so Boot Admin links never show Whitelabel pages
- include `comunes` module in Gateway and Discovery server
- lower log output for failed admin registration in all services

## Testing
- `./mvnw -q -pl comunes test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68739b501830832498b72104939313ce