### PR TITLE
Fix missing version for comunes dependency

### DIFF
--- a/API-gateway/pom.xml
+++ b/API-gateway/pom.xml
@@ -71,6 +71,7 @@
         <dependency>
             <groupId>ar.org.hospitalcuencaalta</groupId>
             <artifactId>comunes</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/servidor-para-descubrimiento/pom.xml
+++ b/servidor-para-descubrimiento/pom.xml
@@ -124,6 +124,7 @@
         <dependency>
             <groupId>ar.org.hospitalcuencaalta</groupId>
             <artifactId>comunes</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- fix missing version for comunes in API gateway and discovery server modules

## Testing
- `./mvnw -q -e -DskipTests clean package` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6873a1e5e7588324a2873dc9bc624d65