### PR TITLE
Fix Eureka server test config

### DIFF
--- a/servidor-para-descubrimiento/src/test/resources/application.properties
+++ b/servidor-para-descubrimiento/src/test/resources/application.properties
@@ -1,3 +1,2 @@
-eureka.client.enabled=false
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false


### PR DESCRIPTION
## Summary
- remove `eureka.client.enabled` from discovery server test properties so the ApplicationInfoManager bean is created

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6873a46d21ec83249e33195cec27dd33