### PR TITLE
Fix API-Gateway test context for WebFlux

### DIFF
--- a/API-gateway/src/test/java/ar/org/hospitalcuencaalta/api_gateway/ApiGatewayApplicationTests.java
+++ b/API-gateway/src/test/java/ar/org/hospitalcuencaalta/api_gateway/ApiGatewayApplicationTests.java
@@ -3,7 +3,7 @@ package ar.org.hospitalcuencaalta.api_gateway;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ApiGatewayApplicationTests {
 
     @Test


### PR DESCRIPTION
## Summary
- ensure ApiGatewayApplicationTests loads a reactive context

## Testing
- `mvn -q dependency:tree` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6874027201f48324981745e0968a51cd