### PR TITLE
Specify admin management url for services

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -291,6 +291,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}/actuator
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
 
 # Exponer métricas para el monitoreo

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -40,6 +40,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_contrato.controlad
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}/actuator
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
 
 # Exponer métricas para el monitoreo

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -64,6 +64,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_empleado.controlad
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}/actuator
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
 
 # Exponer métricas para el monitoreo

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -51,6 +51,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_nomina.controlador
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}/actuator
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
 
 # Exponer métricas para el monitoreo

--- a/servicio-openapi-ui/src/main/resources/application.properties
+++ b/servicio-openapi-ui/src/main/resources/application.properties
@@ -7,6 +7,7 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}/actuator
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
 
 # Exponer métricas para el monitoreo

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -28,6 +28,7 @@ eureka.server.renewal-percent-threshold=0.49
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
 spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}/actuator
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html
 
 # Exponer métricas para el monitoreo


### PR DESCRIPTION
## Summary
- configure `management-base-url` for Spring Boot Admin client

## Testing
- `./mvnw -q test` *(fails: unable to download Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68747654e9d48324b2989392c596aa02