### PR TITLE
Fix admin client URL property

### DIFF
--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -290,7 +290,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-consultas/src/main/resources/application.properties
+++ b/servicio-consultas/src/main/resources/application.properties
@@ -38,7 +38,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_consultas.controla
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-contrato/src/main/resources/application.properties
+++ b/servicio-contrato/src/main/resources/application.properties
@@ -39,7 +39,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_contrato.controlad
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-empleado/src/main/resources/application.properties
+++ b/servicio-empleado/src/main/resources/application.properties
@@ -63,7 +63,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_empleado.controlad
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-entrenamiento/src/main/resources/application.properties
+++ b/servicio-entrenamiento/src/main/resources/application.properties
@@ -46,7 +46,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_entrenamiento.cont
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-nomina/src/main/resources/application.properties
+++ b/servicio-nomina/src/main/resources/application.properties
@@ -50,7 +50,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_nomina.controlador
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-openapi-ui/src/main/resources/application.properties
+++ b/servicio-openapi-ui/src/main/resources/application.properties
@@ -6,7 +6,7 @@ eureka.instance.instance-id=${spring.application.name}:${spring.application.inst
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servicio-orquestador/src/main/resources/application.properties
+++ b/servicio-orquestador/src/main/resources/application.properties
@@ -163,7 +163,7 @@ springdoc.packages-to-scan=ar.org.hospitalcuencaalta.servicio_orquestador.contro
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 eureka.instance.prefer-ip-address=true

--- a/servidor-para-descubrimiento/src/main/resources/application.properties
+++ b/servidor-para-descubrimiento/src/main/resources/application.properties
@@ -27,7 +27,7 @@ eureka.server.renewal-percent-threshold=0.49
 
 # Spring Boot Admin
 spring.boot.admin.client.url=http://localhost:9090
-spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+spring.boot.admin.client.instance.service-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.management-base-url=http://localhost:${server.port}
 spring.boot.admin.client.instance.prefer-ip=true
 spring.boot.admin.client.instance.metadata.swagger-url=http://localhost:${server.port}/swagger-ui.html

--- a/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/service/MicroserviceManager.java
+++ b/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/service/MicroserviceManager.java
@@ -34,7 +34,7 @@ public class MicroserviceManager {
         for (int i = 0; i < count; i++) {
             int port = findFreePort();
             String args = "--server.port=" + port +
-                    ",--spring.boot.admin.client.instance.service-base-url=http://localhost:" + port;
+                    ",--spring.boot.admin.client.instance.service-url=http://localhost:" + port;
             ProcessBuilder pb = new ProcessBuilder("./mvnw", "spring-boot:run",
                     "-Dspring-boot.run.arguments=" + args);
             pb.directory(new File(dir));


### PR DESCRIPTION
## Summary
- update Spring Boot Admin service URL properties to use the correct key
- adjust MicroserviceManager to launch services with the new argument

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68748ce34d5483249e466436e3efdb8a