### PR TITLE
fix: correct CLI args for monitoring

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -153,6 +153,7 @@ Las responsabilidades de cada módulo y su ubicación principal se detallan a co
 * *API-gateway* -> se encamina todo el tráfico en `API-gateway/src/main/java` utilizando Spring Cloud Gateway. Las rutas se definen en `application.properties` y se balancea la carga gracias a la integración con Eureka.
 * *servidor-para-descubrimiento* -> se ejecuta un servidor Eureka en `servidor-para-descubrimiento/src/main/java` para registrar cada microservicio.
 * *servidor-para-monitoreo* -> se centraliza el monitoreo en `servidor-para-monitoreo/src/main/java` a través de Spring Boot Admin. Los servicios reportan sus métricas automáticamente.
+**Importante**: todos los módulos se registran en Spring Boot Admin utilizando la propiedad `spring.boot.admin.client.instance.service-url`. Versiones previas usaban `service-base-url` y provocaban fallos intermitentes en la consola de monitoreo.
 * *servicio-openapi-ui* -> se sirve la documentación en `servicio-openapi-ui/src/main/java` mediante ReDoc. Las especificaciones se obtienen desde el API Gateway.
 * *comunes* -> se almacenan entidades y utilidades compartidas en `comunes/src/main/java`. Este módulo se utiliza como dependencia del resto.
 

--- a/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/service/MicroserviceManager.java
+++ b/servidor-para-monitoreo/src/main/java/ar/org/hospitalcuencaalta/servidor_para_monitoreo/service/MicroserviceManager.java
@@ -34,7 +34,7 @@ public class MicroserviceManager {
         for (int i = 0; i < count; i++) {
             int port = findFreePort();
             String args = "--server.port=" + port +
-                    ",--spring.boot.admin.client.instance.service-url=http://localhost:" + port;
+                    " --spring.boot.admin.client.instance.service-url=http://localhost:" + port;
             ProcessBuilder pb = new ProcessBuilder("./mvnw", "spring-boot:run",
                     "-Dspring-boot.run.arguments=" + args);
             pb.directory(new File(dir));


### PR DESCRIPTION
## Summary
- fix MicroserviceManager CLI arg delimiter so each service registers with Spring Boot Admin

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68751b17375483248a938ea54e1408b7